### PR TITLE
관리자 헤더 로그아웃 기능 구현 (issue #91)

### DIFF
--- a/src/common/components/confirmModal/index.tsx
+++ b/src/common/components/confirmModal/index.tsx
@@ -19,9 +19,9 @@ function ConfirmModal({
 }: PropsWithChildren<ConfirmModalProps>) {
   usePreventScroll(isOpen);
   const router = useRouter();
-  const ref = useOutsideClick(() => onClose());
+  const ref = useOutsideClick(() => handleClose());
 
-  const handleConfirm = () => {
+  const handleClose = () => {
     onClose();
     if (redirectTo) {
       router.push(redirectTo);
@@ -32,7 +32,7 @@ function ConfirmModal({
     <Modal isOpen={isOpen} onClose={onClose}>
       <Modal.Content ref={ref} className={S.content}>
         <Modal.Body className={S.body}>{children}</Modal.Body>
-        <Button variant="primary" className={S.Button} onClick={handleConfirm}>
+        <Button variant="primary" className={S.Button} onClick={handleClose}>
           확인
         </Button>
       </Modal.Content>

--- a/src/common/components/header/adminHeader/adminHeader.css.ts
+++ b/src/common/components/header/adminHeader/adminHeader.css.ts
@@ -38,3 +38,17 @@ export const RightAreaText = style({
   fontWeight: 600,
   marginLeft: '8px',
 });
+
+export const RightSideContainer = style({
+  display: 'flex',
+  justifyContent: 'start',
+  alignItems: 'center',
+  gap: '30px',
+});
+
+export const RightSideText = style({
+  fontSize: vars.fonts.body2,
+  color: vars.colors.surface.bright,
+  fontWeight: 500,
+  cursor: 'pointer',
+});

--- a/src/common/components/header/adminHeader/index.tsx
+++ b/src/common/components/header/adminHeader/index.tsx
@@ -8,23 +8,37 @@ import Image from 'next/image';
 import Link from 'next/link';
 import * as S from './adminHeader.css';
 import { AdminAuthProvider, useAuthStore } from '@/common/store/adminAuthStore';
+import { useLogoutMutation } from '@/hooks/useAdminMutation';
 
 function AdminHeader() {
   const isVisible = useScrollObserver();
   const { profile } = useAuthStore();
+  const { handleLogout } = useLogoutMutation();
+  const handleLogoutClick = () => {
+    handleLogout();
+  };
+
   return (
-    <AdminAuthProvider>
-      <Header isVisible={isVisible} className={S.InnerWrapper}>
-        <Link href={ROUTES.ADMIN}>
-          <Image src={mainlogo} className={S.Logo} alt="Main Logo" />
-        </Link>
-        <p className={S.AdminMessage}>관리자 모드로 접속하셨습니다.</p>
-        <div className={S.RightArea}>
-          <span className={S.RightAreaIcon}></span>
-          <p className={S.RightAreaText}>{profile?.clubName ?? '동아리명'}</p>
-        </div>
-      </Header>
-    </AdminAuthProvider>
+    <>
+      <AdminAuthProvider>
+        <Header isVisible={isVisible} className={S.InnerWrapper}>
+          <Link href={ROUTES.ADMIN}>
+            <Image src={mainlogo} className={S.Logo} alt="Main Logo" />
+          </Link>
+          <p className={S.AdminMessage}>관리자 모드로 접속하셨습니다.</p>
+
+          <div className={S.RightSideContainer}>
+            <p className={S.RightSideText} onClick={handleLogoutClick}>
+              로그아웃
+            </p>
+            <div className={S.RightArea}>
+              <span className={S.RightAreaIcon}></span>
+              <p className={S.RightAreaText}>{profile?.clubName ?? '동아리명'}</p>
+            </div>
+          </div>
+        </Header>
+      </AdminAuthProvider>
+    </>
   );
 }
 

--- a/src/common/store/adminAuthStore.tsx
+++ b/src/common/store/adminAuthStore.tsx
@@ -25,7 +25,7 @@ export const useAuthStore = create<AuthState>((set) => ({
 }));
 
 export const AdminAuthProvider = ({ children }: PropsWithChildren) => {
-  const { data: profile, isLoading } = useAdminProfile();
+  const { data: profile } = useAdminProfile();
   const setProfile = useAuthStore((state) => state.setProfile);
 
   useEffect(() => {

--- a/src/hooks/useAdminMutation.ts
+++ b/src/hooks/useAdminMutation.ts
@@ -46,8 +46,9 @@ export const useLogoutMutation = () => {
       queryClient.invalidateQueries({ queryKey: adminProfile });
       router.push(ROUTES.ADMIN_LOGIN);
     },
-    onError: () => {
+    onError: (error) => {
       alert('로그아웃 중 오류가 발생했습니다.');
+      console.error('Logout error:', error);
     },
   });
 


### PR DESCRIPTION
### 작업 내용
어드민 헤더에 로그아웃 기능을 추가 구현했습니다.
성공시 어드민 로그인 페이지로 리다이렉트됩니다.
디자인이 어떨지는 모르겠지만.. 클라이언트 헤더를 보면서 얼추 맞추어보았어요 ㅎㅎ
<img width="1897" height="79" alt="image" src="https://github.com/user-attachments/assets/d6ddfbf9-18af-4e94-bb20-8f721023e196" />

### 연관 이슈
close #91


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 관리자 헤더에 "로그아웃" 버튼이 추가되어 클릭 시 로그아웃 기능을 사용할 수 있습니다.

* **스타일**
  * 관리자 헤더 우측 영역 및 로그아웃 텍스트에 새로운 스타일이 적용되었습니다.

* **버그 수정**
  * 로그아웃 과정에서 오류 발생 시 콘솔에 에러 메시지가 출력됩니다.

* **리팩터**
  * 모달 닫기 및 리디렉션 동작이 하나의 핸들러로 통합되어 일관된 동작을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->