### PR TITLE
에러 추적 후 버그 해결(issue #180)

### DIFF
--- a/src/components/admin/clubInfo/ClubBox.tsx
+++ b/src/components/admin/clubInfo/ClubBox.tsx
@@ -38,7 +38,7 @@ export default function ClubBox(props: ClubBoxProps) {
     clubUniv,
   } = props;
   const { isOpen, handleModalClose, handleModalOpen } = useModal();
-  const { handleRecruitmentToggle } = useRecruitmentToggle(handleModalOpen, profile!.clubId);
+  const { handleRecruitmentToggle } = useRecruitmentToggle(handleModalOpen, profile?.clubId ?? '');
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleCloseRecruit = () => {

--- a/src/components/admin/clubInfo/index.tsx
+++ b/src/components/admin/clubInfo/index.tsx
@@ -13,17 +13,18 @@ import { useAdminClubInfo, useAdminClubPatch } from '@/hooks/useClubInfo';
 import ConfirmModal from '@/common/components/confirmModal';
 import { useModal } from '@/hooks/useModal';
 import { useAuthStore } from '@/common/store/adminAuthStore';
+import LoadingSpinner from '@/common/ui/loading';
 
 function AdminClubInfo() {
   const [isEditing, setIsEditing] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { profile } = useAuthStore();
 
-  const { data } = useAdminClubInfo(profile!.clubId);
-  const [clubInfo, setClubInfo] = useState<AdminClubIntro>(data);
+  const { data, isLoading } = useAdminClubInfo(profile?.clubId ?? '');
+  const [clubInfo, setClubInfo] = useState<AdminClubIntro | null>(data || null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const { isOpen, handleModalClose, handleModalOpen } = useModal();
-  const { handleClubInfoPatch } = useAdminClubPatch(handleModalOpen, profile!.clubId);
+  const { handleClubInfoPatch } = useAdminClubPatch(handleModalOpen, profile?.clubId ?? '');
 
   const handleClubInfoChange = (updated: Partial<AdminClubIntro>) => {
     setClubInfo((prev) => (prev ? { ...prev, ...updated } : prev));
@@ -59,6 +60,27 @@ function AdminClubInfo() {
     setSelectedFile(null);
   }, [data, isEditing]); // <- data 변경 감지
 
+  const emptyAdminClub: AdminClubIntro = {
+    name: '',
+    clubType: '',
+    clubCategory: '',
+    customCategory: '',
+    recruiting: false,
+    summary: '',
+    profileImageUrl: '',
+    clubMemberCount: 0,
+    applyStartDate: '',
+    applyDeadLine: '',
+    grades: [],
+    maxApplyCount: 0,
+    content: '',
+    clubUniv: '',
+  };
+
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
   return (
     <>
       <div className={S.container}>
@@ -72,7 +94,7 @@ function AdminClubInfo() {
               }}
             >
               <Image
-                src={clubInfo.profileImageUrl || clubImg}
+                src={clubInfo?.profileImageUrl || clubImg}
                 alt="동아리 사진"
                 width={212}
                 height={224}
@@ -99,10 +121,14 @@ function AdminClubInfo() {
               />
             )}
 
-            <ClubBox {...clubInfo} onChange={handleClubInfoChange} isEditing={isEditing} />
+            <ClubBox
+              {...(clubInfo ?? emptyAdminClub)}
+              onChange={handleClubInfoChange}
+              isEditing={isEditing}
+            />
           </div>
           <RightSideBar
-            {...clubInfo}
+            {...(clubInfo ?? emptyAdminClub)}
             onEditClick={() => setIsEditing(true)}
             isEditing={isEditing}
             handleSave={handleSave}
@@ -115,7 +141,7 @@ function AdminClubInfo() {
           />
           <MDEditor
             isEditing={isEditing}
-            introduction={clubInfo.content}
+            introduction={clubInfo?.content ?? ''}
             onChange={(content) => handleClubInfoChange({ content })}
           />
         </div>

--- a/src/components/admin/clubMember/MemberList.tsx
+++ b/src/components/admin/clubMember/MemberList.tsx
@@ -18,8 +18,8 @@ export default function MemberList({ isEditing }: { isEditing: boolean }) {
   const { profile } = useAuthStore();
   const { clubMembers, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useClubMemberInfinite({
-      enabled: true,
-      clubId: profile!.clubId,
+      enabled: !!profile?.clubId,
+      clubId: profile?.clubId,
     });
   const router = useRouter();
   // 무한스크롤을 위한 useInView 훅

--- a/src/components/admin/clubMember/RightSide.tsx
+++ b/src/components/admin/clubMember/RightSide.tsx
@@ -5,9 +5,14 @@ import { useFollowSidebar } from '@/hooks/useFollowSidebar';
 import { useAuthStore } from '@/common/store/adminAuthStore';
 
 export default function RightSide() {
-  const { profile } = useAuthStore();
-  const { data } = useGradeCount({ clubId: profile!.clubId });
+  const { profile } = useAuthStore((state) => state);
+  const { data, isLoading } = useGradeCount({ clubId: profile?.clubId ?? '' });
   const { barPosition } = useFollowSidebar({ initialPosition: 216 });
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
   return (
     <div
       className={S.container}

--- a/src/hooks/useClubInfo.ts
+++ b/src/hooks/useClubInfo.ts
@@ -1,4 +1,4 @@
-import { useSuspenseQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useSuspenseQuery, useMutation, useQueryClient, useQuery } from '@tanstack/react-query';
 import { clubInfoKey } from './queries/key';
 import { getClubInfo } from '@/components/clubInfo/api/getClubInfo';
 import { getAdminClubInfo } from '@/components/admin/clubInfo/api/getClubInfo';
@@ -19,9 +19,10 @@ export const useClubInfo = (clubId: string) => {
 
 export const useAdminClubInfo = (clubId: string) => {
   const { adminClubInfo } = clubInfoKey;
-  const { data, isLoading, refetch } = useSuspenseQuery({
+  const { data, isLoading, refetch } = useQuery({
     queryKey: adminClubInfo,
     queryFn: () => getAdminClubInfo(clubId),
+    enabled: !!clubId,
   });
   return { data, isLoading, refetch };
 };

--- a/src/hooks/useClubMember.ts
+++ b/src/hooks/useClubMember.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { getGradeCount } from '@/components/admin/clubMember/api/getGradeCount';
 import { getSearchMembers } from '@/components/admin/clubMember/api/getSearchMembers';
 import { clubMemberKey } from './queries/key';
@@ -12,9 +12,10 @@ import { CustomHttpError } from '@/common/apis/apiClient';
 
 export const useGradeCount = ({ clubId }: { clubId: string }) => {
   const { gradeCount } = clubMemberKey;
-  const { data, isLoading } = useSuspenseQuery({
+  const { data, isLoading } = useQuery({
     queryKey: [gradeCount],
     queryFn: () => getGradeCount(clubId),
+    enabled: !!clubId,
   });
   return { data, isLoading };
 };


### PR DESCRIPTION
### 작업 내용
배포후 에러가 발생하여 해결했습니다. 
clubId가 상태에 반영되기 전에 clubId를 필요로하는 네트워크 요청이 undefined가 뜨는 문제가 있었습니다.
즉 타이밍 이슈이기에 관련 쿼리훅 enabled 속성을 이용해 네트워크 요청을 막아 문제를 해결했습니다. 

- 에러 트래킹 사진
<img width="731" height="178" alt="image" src="https://github.com/user-attachments/assets/d916247c-498f-45cf-bc47-348c2d193f0f" />


### 연관 이슈
 close #180


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 클럽 정보 및 멤버 사이드 패널에 로딩 스피너가 표시됩니다.
  - 데이터가 아직 없을 때도 기본값으로 안정적인 화면을 제공합니다.
- Bug Fixes
  - 프로필/클럽 ID가 없을 때 발생하던 충돌과 불필요한 로딩을 방지했습니다.
  - 로딩 전 미정의 필드로 인한 화면 깨짐을 예방했습니다.
- Refactor
  - 데이터 요청을 필요 시에만 수행하도록 로딩 제어를 개선했습니다.
  - 로딩 상태를 명확히 노출해 사용자 피드백을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->