### PR TITLE
공용적으로 사용되는 alert창 삭제 (issue #188)

### DIFF
--- a/src/app/queryProvider.tsx
+++ b/src/app/queryProvider.tsx
@@ -86,10 +86,6 @@ async function handleMutationError(
       return;
     }
   }
-  if (err instanceof CustomHttpError && typeof window !== 'undefined') {
-    alert('알 수 없는 에러가 발생했습니다. 다시 시도해주세요.');
-    return;
-  }
 }
 
 const retriedQueries = new WeakSet<Query<unknown, unknown, unknown>>();


### PR DESCRIPTION
### 작업 내용
공용적으로 사용되는 alert창을 삭제하고 에러시 발생되는 메세지를 따로 관리합니다.

### 연관 이슈
close #188


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 인증과 무관한 변이 오류 발생 시 표시되던 일반 경고창(“알 수 없는 에러가 발생했습니다. 다시 시도해주세요.”)을 제거했습니다.
  - 이제 해당 경우에도 화면 흐름이 중단되지 않으며, 인증/권한 오류에 대한 안내는 기존과 동일하게 동작합니다.
  - 불필요한 팝업 알림이 사라져 방해 요소가 줄고, 후속 오류 처리 흐름이 더 원활해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->