### PR TITLE
질문에 대한 각 답변 가드 설정 (issue #192)

### DIFF
--- a/src/components/admin/applicants/applicantDetailModal/answerFactory/answerCheckbox.tsx
+++ b/src/components/admin/applicants/applicantDetailModal/answerFactory/answerCheckbox.tsx
@@ -7,6 +7,7 @@ interface AnswerCheckboxProps {
 }
 
 function AnswerCheckbox({ answer }: AnswerCheckboxProps) {
+  const isValueExist = answer.value === null;
   return (
     <div className={S.answer}>
       <label className={S.label}>
@@ -20,7 +21,7 @@ function AnswerCheckbox({ answer }: AnswerCheckboxProps) {
             type="checkbox"
             name={answer.title}
             value={option}
-            defaultChecked={answer.value.includes(option)}
+            defaultChecked={isValueExist ? false : answer.value.includes(option)}
             label={option}
             className={S.answerCheckbox}
             img={check}

--- a/src/components/admin/applicants/applicantDetailModal/answerFactory/answerFile.tsx
+++ b/src/components/admin/applicants/applicantDetailModal/answerFactory/answerFile.tsx
@@ -29,10 +29,12 @@ function AnswerFile({ answer, applicantName }: AnswerFileProps) {
         {answer.isEssential && <span className={S.essential}>*</span>}
       </label>
       <h3 className={S.subTitle}>{answer.subTitle}</h3>
-      <div className={S.fileDownload} onClick={() => triggerFileDownload(answer.value)}>
-        <Image src={FileDown} alt="파일 다운" />
-        <p className={S.fileDownloadText}>파일 다운</p>
-      </div>
+      {answer.value && (
+        <div className={S.fileDownload} onClick={() => triggerFileDownload(answer.value)}>
+          <Image src={FileDown} alt="파일 다운" />
+          <p className={S.fileDownloadText}>파일 다운</p>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/admin/applicants/applicantDetailModal/answerFactory/answerInput.tsx
+++ b/src/components/admin/applicants/applicantDetailModal/answerFactory/answerInput.tsx
@@ -13,7 +13,12 @@ function AnswerInput({ answer }: AnswerInputProps) {
         {answer.isEssential && <span className={S.essential}>*</span>}
       </label>
       <h3 className={S.subTitle}>{answer.subTitle}</h3>
-      <Input variant="secondary" readOnly className={S.AnswerInput} value={answer.value} />
+      <Input
+        variant="secondary"
+        readOnly
+        className={S.AnswerInput}
+        value={answer.value ?? '작성한 답변이 없습니다.'}
+      />
     </div>
   );
 }

--- a/src/components/admin/applicants/applicantDetailModal/answerFactory/answerRadio.tsx
+++ b/src/components/admin/applicants/applicantDetailModal/answerFactory/answerRadio.tsx
@@ -8,6 +8,8 @@ interface AnswerRadioProps {
 }
 
 function AnswerRadio({ answer }: AnswerRadioProps) {
+  const isValueExist = answer.value === null;
+
   return (
     <div className={S.answer}>
       <label className={S.label}>
@@ -21,7 +23,7 @@ function AnswerRadio({ answer }: AnswerRadioProps) {
             type="radio"
             name={answer.title}
             value={option}
-            defaultChecked={answer.value === option}
+            defaultChecked={isValueExist ? false : answer.value === option}
             label={option}
             className={S.answerCheckbox}
             img={check}

--- a/src/components/admin/applicants/applicantDetailModal/answerFactory/answerTextarea.tsx
+++ b/src/components/admin/applicants/applicantDetailModal/answerFactory/answerTextarea.tsx
@@ -14,7 +14,7 @@ function AnswerTextarea({ answer }: AnswerTextareaProps) {
       <h3 className={S.subTitle}>{answer.subTitle}</h3>
       <textarea
         className={S.AnswerTextarea}
-        value={answer.value}
+        value={answer.value ?? '작성한 답변이 없습니다.'}
         readOnly
         rows={4}
         style={{ resize: 'none', width: '100%' }}


### PR DESCRIPTION
### 작업 내용
지원자 정보에 대한 각 답변들이 null일 경우, 가드를 설정해 에러를 해결했습니다.

### 연관 이슈
close #192


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 응답이 없을 때 체크박스/라디오가 기본 선택되지 않도록 수정.
  * 파일 값이 없을 경우 다운로드 UI가 표시되지 않도록 조정해 오작동 방지.

* **New Features**
  * 텍스트 입력/텍스트 영역에서 응답이 없을 때 기본 안내 문구(“작성한 답변이 없습니다.”) 표시.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->