### PR TITLE
권한이 필요한 query 재시도 문제 해결 (issue #198)

### DIFF
--- a/src/app/queryProvider.tsx
+++ b/src/app/queryProvider.tsx
@@ -108,8 +108,11 @@ async function handleQueryError(error: Error, query: Query<unknown, unknown, unk
         await postRefresh();
       }
       await query.fetch();
+      retriedQueries.delete(query);
     } catch (error) {
+      retriedQueries.delete(query);
       if (typeof window !== 'undefined') {
+        console.error('토큰 재발급 실패:', error);
         alert('세션이 만료되었습니다. 다시 로그인해주세요.');
 
         if (isAdmin) {
@@ -119,7 +122,7 @@ async function handleQueryError(error: Error, query: Query<unknown, unknown, unk
           localStorage.removeItem('name');
         }
       }
-      throw error;
+      return;
     }
   }
 }


### PR DESCRIPTION
### 작업 내용
권한 오류가 날 때, 쿼리 재시도 1회 호출 이후 정상적으로 호출되지 않는 문제가 있었습니다.
기존에 무한루프를 방지하기 위해, `retriedQueries`로 제어하고 있었는데, 캐싱때문에 `handleQueryError` 를 실행하지 못했던 이유임을 발견했습니다.
그래서, 정상 호출 후 `retriedQueries` 삭제하는 방식으로 문제를 해결했습니다.

### 연관 이슈
close #198


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 토큰 재발급 후 재시도한 조회가 정상적으로 정리되지 않아 중복 처리·지속 오류가 발생하던 문제를 해결했습니다.
  - 재시도 실패 시 내부 상태를 즉시 정리해 이후 동작의 안정성을 높였습니다.
  - 브라우저에서 토큰 재발급 실패 시 콘솔 오류 로그를 추가했습니다.
  - 오류 전파 방식을 조정해 불필요한 예외로 인한 앱 중단 가능성을 줄였습니다.
  - 사용자 알림 및 리다이렉트 흐름은 기존과 동일합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->