### PR TITLE
지원폼 Input 수정(issue #212)

### DIFF
--- a/src/components/apply/BasicInfoSection.tsx
+++ b/src/components/apply/BasicInfoSection.tsx
@@ -45,25 +45,24 @@ export default function BasicInfoSection({ register, errors }: BasicInfoSectionP
             </div>
           )}
         </div>
-        <div className={S.FormContentContainer}>
-          <div className={S.FormContentTitle}>
-            학과<span className={S.FormContentTitleEssential}>*</span>
-          </div>
-          <input
-            size={1}
-            type="text"
-            className={S.FormInput}
-            placeholder="학과를 입력해주세요."
-            {...register('major')}
-          />
-          {errors.major && (
-            <div style={{ color: 'red', fontSize: '12px', marginTop: '4px' }}>
-              {errors.major.message}
-            </div>
-          )}
-        </div>
       </div>
-
+      <div className={S.FormContentContainer}>
+        <div className={S.FormContentTitle}>
+          학과<span className={S.FormContentTitleEssential}>*</span>
+        </div>
+        <input
+          size={1}
+          type="text"
+          className={S.FormInput}
+          placeholder="학과를 입력해주세요."
+          {...register('major')}
+        />
+        {errors.major && (
+          <div style={{ color: 'red', fontSize: '12px', marginTop: '4px' }}>
+            {errors.major.message}
+          </div>
+        )}
+      </div>
       <div className={S.FormContentFlex}>
         <div className={S.FormContentContainer}>
           <div className={S.FormContentTitle}>
@@ -98,25 +97,24 @@ export default function BasicInfoSection({ register, errors }: BasicInfoSectionP
             </div>
           )}
         </div>
-        <div className={S.FormContentContainer}>
-          <div className={S.FormContentTitle}>
-            전화번호<span className={S.FormContentTitleEssential}>*</span>
-          </div>
-          <input
-            size={1}
-            type="text"
-            className={S.FormInput}
-            placeholder="010-0000-0000"
-            {...register('phone')}
-          />
-          {errors.phone && (
-            <div style={{ color: 'red', fontSize: '12px', marginTop: '4px' }}>
-              {errors.phone.message}
-            </div>
-          )}
-        </div>
       </div>
-
+      <div className={S.FormContentContainer}>
+        <div className={S.FormContentTitle}>
+          전화번호<span className={S.FormContentTitleEssential}>*</span>
+        </div>
+        <input
+          size={1}
+          type="text"
+          className={S.FormInput}
+          placeholder="010-0000-0000"
+          {...register('phone')}
+        />
+        {errors.phone && (
+          <div style={{ color: 'red', fontSize: '12px', marginTop: '4px' }}>
+            {errors.phone.message}
+          </div>
+        )}
+      </div>
       <div className={S.FormContentContainer}>
         <div className={S.FormContentTitle}>
           재학여부<span className={S.FormContentTitleEssential}>*</span>

--- a/src/components/apply/BasicInfoSection.tsx
+++ b/src/components/apply/BasicInfoSection.tsx
@@ -45,23 +45,23 @@ export default function BasicInfoSection({ register, errors }: BasicInfoSectionP
             </div>
           )}
         </div>
-      </div>
-      <div className={S.FormContentContainer}>
-        <div className={S.FormContentTitle}>
-          학과<span className={S.FormContentTitleEssential}>*</span>
-        </div>
-        <input
-          size={1}
-          type="text"
-          className={S.FormInput}
-          placeholder="학과를 입력해주세요."
-          {...register('major')}
-        />
-        {errors.major && (
-          <div style={{ color: 'red', fontSize: '12px', marginTop: '4px' }}>
-            {errors.major.message}
+        <div className={S.FormContentContainer}>
+          <div className={S.FormContentTitle}>
+            학과<span className={S.FormContentTitleEssential}>*</span>
           </div>
-        )}
+          <input
+            size={1}
+            type="text"
+            className={S.FormInput}
+            placeholder="학과를 입력해주세요."
+            {...register('major')}
+          />
+          {errors.major && (
+            <div style={{ color: 'red', fontSize: '12px', marginTop: '4px' }}>
+              {errors.major.message}
+            </div>
+          )}
+        </div>
       </div>
       <div className={S.FormContentFlex}>
         <div className={S.FormContentContainer}>
@@ -97,23 +97,23 @@ export default function BasicInfoSection({ register, errors }: BasicInfoSectionP
             </div>
           )}
         </div>
-      </div>
-      <div className={S.FormContentContainer}>
-        <div className={S.FormContentTitle}>
-          전화번호<span className={S.FormContentTitleEssential}>*</span>
-        </div>
-        <input
-          size={1}
-          type="text"
-          className={S.FormInput}
-          placeholder="010-0000-0000"
-          {...register('phone')}
-        />
-        {errors.phone && (
-          <div style={{ color: 'red', fontSize: '12px', marginTop: '4px' }}>
-            {errors.phone.message}
+        <div className={S.FormContentContainer}>
+          <div className={S.FormContentTitle}>
+            전화번호<span className={S.FormContentTitleEssential}>*</span>
           </div>
-        )}
+          <input
+            size={1}
+            type="text"
+            className={S.FormInput}
+            placeholder="010-0000-0000"
+            {...register('phone')}
+          />
+          {errors.phone && (
+            <div style={{ color: 'red', fontSize: '12px', marginTop: '4px' }}>
+              {errors.phone.message}
+            </div>
+          )}
+        </div>
       </div>
       <div className={S.FormContentContainer}>
         <div className={S.FormContentTitle}>

--- a/src/components/apply/form.css.ts
+++ b/src/components/apply/form.css.ts
@@ -190,6 +190,13 @@ export const FormBasicContainer = style({
 export const FormContentFlex = style({
   display: 'flex',
   gap: '12px',
+
+  '@media': {
+    [`screen and (max-width: ${BREAKPOINTS.desktop}px)`]: {
+      flexDirection: 'column',
+      gap: '20px',
+    },
+  },
 });
 
 export const FormContentContainer = style({

--- a/src/components/password/schema.ts
+++ b/src/components/password/schema.ts
@@ -11,6 +11,9 @@ export const passwordSchema = z
       .string()
       .min(8, '비밀번호는 최소 8자 이상이어야 합니다.')
       .max(20, '비밀번호는 최대 20자까지 가능합니다.')
+      .refine((val) => !/[가-힣]/.test(val), {
+        message: '한글은 입력할 수 없습니다.',
+      })
       .refine((val) => /[a-z]/.test(val), {
         message: '소문자를 포함해야 합니다.',
       })

--- a/src/components/signup/schema.ts
+++ b/src/components/signup/schema.ts
@@ -11,6 +11,9 @@ export const signupSchema = z
       .string()
       .min(8, '비밀번호는 최소 8자 이상이어야 합니다.')
       .max(20, '비밀번호는 최대 20자까지 가능합니다.')
+      .refine((val) => !/[가-힣]/.test(val), {
+        message: '한글은 입력할 수 없습니다.',
+      })
       .refine((val) => /[a-z]/.test(val), {
         message: '소문자를 포함해야 합니다.',
       })


### PR DESCRIPTION
### 작업 내용
지원폼 모바일일때 input수정을 피그마에 수정된걸로 재반영하였습니다
+추가로 회원가입이랑 비밀번호 재설정시 비밀번호에 한글 입력하면 유효성 검사도 추가하였습니다

<img width="368" height="736" alt="스크린샷 2025-09-15 오후 9 21 42" src="https://github.com/user-attachments/assets/a65ba30b-536a-4748-a8c8-75e265b10590" />수정전
<img width="372" height="755" alt="스크린샷 2025-09-15 오후 9 24 05" src="https://github.com/user-attachments/assets/d54d9596-c18b-4cf5-960a-05c6219fb98c" />수정후



### 연관 이슈
 close #212


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * 기본 정보 섹션의 불필요한 공백을 정리해 코드 가독성을 개선했습니다.
  * 폼 레이아웃에 데스크탑 이하 화면에서 세로 배치와 간격을 넓히는 반응형 개선을 적용해 작은 화면에서 입력 필드 간격이 개선됩니다.

* **Bug Fixes**
  * 비밀번호 입력 시 한글 문자를 허용하지 않도록 검증을 추가해 한글 입력 시 명확한 오류 메시지를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->