### PR TITLE
스크롤 최상단 훅 생성후 동아리 상세페이지에 적용(issue #277)

### DIFF
--- a/apps/web/src/components/clubInfo/index.tsx
+++ b/apps/web/src/components/clubInfo/index.tsx
@@ -12,12 +12,16 @@ import { useClubInfo } from '@/hooks/useClubInfo';
 import LoadingSpinner from '@/common/ui/loading';
 import { useModal } from '@/hooks/useModal';
 import ConfirmModal from '@/common/components/confirmModal';
+import { useScrollTop } from '@/hooks/useScrollTop';
 
 const ClubInfoPage = () => {
   const { clubId } = useParams();
   const { data } = useClubInfo(clubId as string);
   const [isLargeScreen, setIsLargeScreen] = useState(false);
   const { isOpen, handleModalClose, handleModalOpen } = useModal();
+
+  useScrollTop();
+
   useEffect(() => {
     const checkScreenSize = () => {
       setIsLargeScreen(window.innerWidth >= 1440);

--- a/apps/web/src/hooks/useScrollTop.ts
+++ b/apps/web/src/hooks/useScrollTop.ts
@@ -1,0 +1,14 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * 페이지(컴포넌트) 마운트 시 스크롤을 최상단으로 이동시키는 훅
+ */
+export const useScrollTop = () => {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.scrollTo({ top: 0, behavior: 'auto' });
+  }, []);
+};
+


### PR DESCRIPTION
### 작업 내용
스크롤 최상단 훅 생성후 동아리 상세페이지에 적용하였습니다

https://github.com/user-attachments/assets/d223c80a-7210-4a36-93d5-2056ca632726


### 연관 이슈
close #277


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The club info page now automatically scrolls to the top when you navigate to it, providing a more consistent viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->