### PR TITLE
동아리 소개 이미지 최적화(issue #292)

### DIFF
--- a/apps/web/src/components/clubInfo/ClubProfile.tsx
+++ b/apps/web/src/components/clubInfo/ClubProfile.tsx
@@ -8,6 +8,7 @@ import { usePostFavorite } from '@/hooks/useFavoriteMutation';
 import { getKoreanType } from '@/common/util/getKoreanType';
 import { getKoreanCategory } from '@/common/util/getKoreanCategory';
 import clubImg from '@/assets/clubImg.svg';
+import { BREAKPOINTS } from '@/common/constants';
 
 export default function ClubProfile({
   clubIntro,
@@ -34,12 +35,13 @@ export default function ClubProfile({
 
   return (
     <div className={S.clubProfile}>
-        <Image
+      <Image
         src={profileImageUrl || clubImg}
         alt={name}
         width={212}
         height={206}
         className={S.imageStyle}
+        sizes={`(max-width: ${BREAKPOINTS.desktop}px) 58px, 212px`}
       />
       <div className={S.RightFlex}>
         <div className={S.type} style={{ marginBottom: '2px' }}>


### PR DESCRIPTION
### 작업 내용
이전에는 동아리 소개 이미지를 모바일일때도 데스크톱과 동일한 이미지 파일크기를 불러왔었습니다.
Image 컴포넌트에 sizes를 추가하여 모바일때와 데스크톱일때 불러오는 이미지 파일 크기를 구분하였습니다
<img width="560" height="51" alt="스크린샷 2026-02-26 오후 3 44 59" src="https://github.com/user-attachments/assets/cf539d95-4fbd-4bcf-8e26-3008f6cc6e9b" />변경전

<img width="557" height="48" alt="스크린샷 2026-02-26 오후 3 45 40" src="https://github.com/user-attachments/assets/044fe116-f386-4aeb-a538-0245821ac96d" />변경후


### 연관 이슈
close #292 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated club profile image component with responsive sizing based on screen breakpoints.
  * Minor formatting adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->