### PR TITLE
웹 접근성 개선(issue #294)

### DIFF
--- a/apps/web/src/app/(default-header)/(with-footer)/login/page.tsx
+++ b/apps/web/src/app/(default-header)/(with-footer)/login/page.tsx
@@ -51,22 +51,28 @@ export default function Page() {
     <div className={S.Container}>
       <div className={S.LoginText}>로그인</div>
       <form className={S.BoxContainer} onSubmit={handleSubmit(onSubmit)}>
-        <div className={S.AuthText({ password: false })}>학번</div>
+        <label htmlFor="studentId" className={S.AuthText({ password: false })}>
+          학번
+        </label>
         <input
           type="text"
           className={S.userInput}
           {...register('studentId')}
           placeholder="학번을 입력하세요"
           maxLength={9}
+          id="studentId"
         />
         {errors.studentId && <p className={S.ErrorText}>{errors.studentId.message}</p>}
 
-        <div className={S.AuthText({ password: true })}>비밀번호</div>
+        <label htmlFor="password" className={S.AuthText({ password: true })}>
+          비밀번호
+        </label>
         <input
           type="password"
           className={S.userInput}
           {...register('password')}
           placeholder="비밀번호를 입력하세요"
+          id="password"
         />
         {errors.password && <p className={S.ErrorText}>{errors.password.message}</p>}
 

--- a/apps/web/src/app/(default-header)/(with-footer)/password/page.tsx
+++ b/apps/web/src/app/(default-header)/(with-footer)/password/page.tsx
@@ -97,7 +97,9 @@ export default function Page() {
           <div className={S.BoxTitle}>이메일 인증</div>
           <div className={S.SubContainer}>
             <div className={S.SubDetailContainer}>
-              <div className={S.BoxSubTitle}>이메일</div>
+              <label htmlFor="studentId" className={S.BoxSubTitle}>
+                이메일
+              </label>
               <div className={S.InputButtonFlex}>
                 <div className={S.EmailBox}>
                   <Input
@@ -105,6 +107,7 @@ export default function Page() {
                     className={S.Input}
                     placeholder="학번을 입력하세요"
                     {...register('studentId')}
+                    id="studentId"
                   />
                   <div className={S.EmailText}>@sangmyung.kr</div>
                 </div>
@@ -123,12 +126,15 @@ export default function Page() {
               )}
             </div>
             <div className={S.SubDetailContainer}>
-              <div className={S.BoxSubTitle}>인증코드</div>
+              <label htmlFor="code" className={S.BoxSubTitle}>
+                인증코드
+              </label>
               <div className={S.InputButtonFlex}>
                 <Input
                   className={S.Input}
                   placeholder="인증코드를 입력하세요"
                   {...register('code')}
+                  id="code"
                 />
                 <Button
                   variant="secondary"
@@ -150,24 +156,30 @@ export default function Page() {
           </div>
           <div className={S.SubContainer}>
             <div className={S.SubDetailContainer}>
-              <div className={S.BoxSubTitle}>새 비밀번호</div>
+              <label htmlFor="password" className={S.BoxSubTitle}>
+                새 비밀번호
+              </label>
               <Input
                 className={S.Input}
                 placeholder="새 비밀번호를 입력하세요"
                 type="password"
                 {...register('password')}
                 disabled={!isVerified}
+                id="password"
               />
               {errors.password && <span className={S.ErrorMessage}>{errors.password.message}</span>}
             </div>
             <div className={S.SubDetailContainer}>
-              <div className={S.BoxSubTitle}>새 비밀번호 재입력</div>
+              <label htmlFor="passwordConfirm" className={S.BoxSubTitle}>
+                새 비밀번호 재입력
+              </label>
               <Input
                 className={S.Input}
                 placeholder="새 비밀번호를 재입력하세요"
                 type="password"
                 {...register('passwordConfirm')}
                 disabled={!isVerified}
+                id="passwordConfirm"
               />
               {errors.passwordConfirm && (
                 <span className={S.ErrorMessage}>{errors.passwordConfirm.message}</span>

--- a/apps/web/src/app/(default-header)/(without-footer)/signup/page.tsx
+++ b/apps/web/src/app/(default-header)/(without-footer)/signup/page.tsx
@@ -107,13 +107,16 @@ export default function Page() {
             <div className={S.LabelText}>이메일 인증</div>
             <div className={S.LabelDetailBox}>
               <div className={S.FlexBox}>
-                <div className={S.LabelDetailText}>이메일</div>
+                <label htmlFor="studentId" className={S.LabelDetailText}>
+                  이메일
+                </label>
                 <div className={S.FlexBox2}>
                   <div className={S.EmailBox}>
                     <input
                       className={S.Input}
                       {...register('studentId')}
                       placeholder="학번을 입력하세요"
+                      id="studentId"
                     />
                     <div className={S.EmailText}>@sangmyung.kr</div>
                   </div>
@@ -130,12 +133,15 @@ export default function Page() {
                 {errors.studentId && <p className={S.ErrorText}>{errors.studentId.message}</p>}
               </div>
               <div className={S.FlexBox}>
-                <div className={S.LabelDetailText}>인증코드</div>
+                <label htmlFor="code" className={S.LabelDetailText}>
+                  인증코드
+                </label>
                 <div className={S.FlexBox2}>
                   <input
                     className={S.Input}
                     {...register('code')}
                     placeholder="인증코드를 입력하세요"
+                    id="code"
                   />
                   <Button
                     variant="secondary"
@@ -156,7 +162,9 @@ export default function Page() {
             <div className={S.LabelText}>비밀번호</div>
             <div className={S.LabelDetailBox}>
               <div className={S.FlexBox}>
-                <div className={S.LabelDetailText}>비밀번호</div>
+                <label htmlFor="password" className={S.LabelDetailText}>
+                  비밀번호
+                </label>
                 <div className={S.FlexBox2}>
                   <input
                     className={S.Input}
@@ -164,12 +172,15 @@ export default function Page() {
                     {...register('password')}
                     placeholder="비밀번호를 입력하세요"
                     disabled={!isVerified}
+                    id="password"
                   />
                 </div>
                 {errors.password && <p className={S.ErrorText}>{errors.password.message}</p>}
               </div>
               <div className={S.FlexBox}>
-                <div className={S.LabelDetailText}>비밀번호 재입력</div>
+                <label htmlFor="confirmPassword" className={S.LabelDetailText}>
+                  비밀번호 재입력
+                </label>
                 <div className={S.FlexBox2}>
                   <input
                     className={S.Input}
@@ -177,6 +188,7 @@ export default function Page() {
                     {...register('confirmPassword')}
                     placeholder="비밀번호를 재입력하세요"
                     disabled={!isVerified}
+                    id="confirmPassword"
                   />
                 </div>
                 {errors.confirmPassword && (
@@ -188,9 +200,9 @@ export default function Page() {
 
           {/* 이름 */}
           <div className={S.LabelBoxContainer} style={{ gap: '166px' }}>
-            <div className={S.LabelText} style={{ alignSelf: 'center' }}>
+            <label htmlFor="name" className={S.LabelText} style={{ alignSelf: 'center' }}>
               이름
-            </div>
+            </label>
             <div className={S.FlexBox}>
               <div className={S.FlexBox2}>
                 <input
@@ -198,6 +210,7 @@ export default function Page() {
                   placeholder="본인의 이름을 기재해주세요"
                   {...register('name')}
                   disabled={!isVerified}
+                  id="name"
                 />
               </div>
               {errors.name && <p className={S.ErrorText}>{errors.name.message}</p>}

--- a/apps/web/src/common/components/header/clientHeader/desktop.tsx
+++ b/apps/web/src/common/components/header/clientHeader/desktop.tsx
@@ -34,9 +34,9 @@ function Desktop<T extends { id: string; name: string; clubType: string }>({
   const { handleLogout } = useLogoutMutation();
   return (
     <Header isVisible={isVisible} className={S.DesktopInnerWrapper}>
-        <Link href={ROUTES.HOME}>
-          <Image src={Mainlogo} className={S.Logo} alt="Main Logo" />
-        </Link>
+      <Link href={ROUTES.HOME}>
+        <Image src={Mainlogo} className={S.Logo} alt="Main Logo" />
+      </Link>
       <div className={S.RightArea}>
         <InputCombobox
           className={S.InputCombobox}
@@ -49,6 +49,7 @@ function Desktop<T extends { id: string; name: string; clubType: string }>({
           onClick={handleNavigate}
           onKeyDown={handleKeyDown}
           placeholder="동아리 이름을 검색하세요."
+          aria-label="동아리 이름을 검색하세요."
         />
         {userName ? (
           <>
@@ -86,7 +87,6 @@ function Desktop<T extends { id: string; name: string; clubType: string }>({
               <Button className={S.ButtonStyle} variant="secondary">
                 회원가입
               </Button>
-            
             </Link>
             <Link href={ROUTES.ADMIN_LOGIN}>
               <Button className={S.ButtonStyle} variant="secondary">

--- a/apps/web/src/common/components/header/clientHeader/mobile.tsx
+++ b/apps/web/src/common/components/header/clientHeader/mobile.tsx
@@ -75,6 +75,7 @@ function Mobile<T extends { id: string; name: string; clubType: string }>({
               onClick={handleNavigate}
               onKeyDown={handleKeyDown}
               placeholder="동아리 이름을 검색하세요."
+              aria-label="동아리 이름을 검색하세요."
             />
           </div>
         )}


### PR DESCRIPTION
### 작업 내용
웹 접근성 개선을 위해 웹 접근성 진단 도구인 wave로 피드백을 받은후 개선하였습니다.
aria-label과 label을 사용하여 개선하였습니다.
<img width="1706" height="957" alt="스크린샷 2026-03-04 오후 4 48 03" src="https://github.com/user-attachments/assets/89cb7040-93ef-4476-8034-fbeb225c6f1f" />
<img width="1710" height="960" alt="스크린샷 2026-03-04 오후 4 48 25" src="https://github.com/user-attachments/assets/fa3fc339-9ff2-45d2-b16c-718130e3a897" />


### 연관 이슈
관련이슈 번호를 close해주세요.
예시 close #294 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Accessibility Improvements**
  * Enhanced form field labels on login, password reset, and sign-up pages to improve screen reader compatibility.
  * Added descriptive accessibility labels to search inputs in desktop and mobile headers for better user assistance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->