### PR TITLE
디자인 시스템 사용량 분석 CLI 도구 추가(issue #302)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,10 @@
     "postbuild": "next-sitemap",
     "start": "next start",
     "lint": "next lint",
-    "analyze": "cross-env ANALYZE=true next build"
+    "analyze": "cross-env ANALYZE=true next build",
+    "analyze:design": "node scripts/analyzeDesign/index.mjs --ast",
+    "codemod": "node scripts/codemod/index.mjs",
+    "codemod:apply": "node scripts/codemod/index.mjs --apply"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -44,11 +47,14 @@
     "zustand": "^5.0.6"
   },
   "devDependencies": {
+    "@babel/parser": "^7.29.3",
+    "@babel/traverse": "^7.29.0",
+    "@babel/types": "^7.29.0",
     "@eslint/eslintrc": "^3",
     "@next/bundle-analyzer": "^16.1.1",
     "@svgr/webpack": "^8.1.0",
-    "@types/node": "^20",
     "@types/dompurify": "^3.0.5",
+    "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vanilla-extract/next-plugin": "^2.4.11",
@@ -56,6 +62,7 @@
     "cross-env": "^10.1.0",
     "eslint": "^9",
     "eslint-config-next": "^15.5.7",
+    "glob": "^13.0.6",
     "msw": "^2.10.1",
     "typescript": "^5"
   },

--- a/apps/web/scripts/analyzeDesign/index.mjs
+++ b/apps/web/scripts/analyzeDesign/index.mjs
@@ -1,0 +1,142 @@
+import { createWriteStream } from 'fs';
+import { globSync } from 'glob';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { b, g, y, d, cy, ANSI_RE } from '../lib/ansi.mjs';
+import { extractThemeColorMap } from '../lib/theme-parser.mjs';
+import { scanFile } from './lib/scanner.mjs';
+import { printHit } from './lib/reporter.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '../..');
+const THEME_FILE = path.resolve(ROOT, 'src/common/styles/theme.css.ts');
+
+const DIVIDER_THIN = '─'.repeat(60);
+const DIVIDER_THIN_SHORT = '─'.repeat(50);
+const DIVIDER_THICK = '═'.repeat(60);
+
+// ─── CLI ─────────────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  return {
+    fileArg: getArgValue(args, '--file'),
+    outputArg: getArgValue(args, '--output'),
+    showAst: args.includes('--ast'),
+    onlyUnknown: args.includes('--unknown'),
+    onlyKnown: args.includes('--known'),
+  };
+}
+
+function getArgValue(args, flag) {
+  const idx = args.indexOf(flag);
+  return idx !== -1 ? args[idx + 1] : null;
+}
+
+// ─── 출력 스트림 ──────────────────────────────────────────────────────────────
+
+function setupFileOutput(outputArg) {
+  if (!outputArg) return;
+
+  const outPath = path.isAbsolute(outputArg) ? outputArg : path.resolve(process.cwd(), outputArg);
+  const fileStream = createWriteStream(outPath, { encoding: 'utf-8' });
+
+  const origLog = console.log.bind(console);
+  console.log = (...parts) => {
+    const line = parts.join(' ');
+    origLog(line);
+    fileStream.write(line.replace(ANSI_RE, '') + '\n');
+  };
+
+  process.on('exit', () => fileStream.end());
+}
+
+// ─── 스캔 대상 파일 ───────────────────────────────────────────────────────────
+
+function resolveTargetFiles(fileArg) {
+  if (fileArg) {
+    return [path.isAbsolute(fileArg) ? fileArg : path.resolve(ROOT, fileArg)];
+  }
+  return globSync('src/**/*.{ts,tsx}', {
+    cwd: ROOT,
+    absolute: true,
+    ignore: ['**/node_modules/**', '**/.next/**', '**/theme.css.ts'],
+  });
+}
+
+// ─── 출력 ────────────────────────────────────────────────────────────────────
+
+function printTokenMap(tokenMap) {
+  console.log(`\n${b('▶ theme.css.ts 색상 맵 추출 중...')}`);
+  console.log(`  ${g(tokenMap.size + '개')} 토큰 발견\n`);
+
+  console.log(b('[ 디자인 토큰 목록 ]'));
+  console.log(DIVIDER_THIN_SHORT);
+  for (const [hex, token] of tokenMap) {
+    console.log(`  ${d(hex.padEnd(12))}  →  ${cy(token)}`);
+  }
+  console.log();
+}
+
+function filterHits(hits, { onlyKnown, onlyUnknown }) {
+  if (onlyKnown) return hits.filter((h) => h.token !== null);
+  if (onlyUnknown) return hits.filter((h) => h.token === null);
+  return hits;
+}
+
+function formatFileSummary(known, unknown) {
+  return [known ? g(`known: ${known}`) : null, unknown ? y(`unknown: ${unknown}`) : null]
+    .filter(Boolean)
+    .join('  ');
+}
+
+function printFileHits(file, hits, showAst) {
+  const known = hits.filter((h) => h.token !== null).length;
+  const unknown = hits.filter((h) => h.token === null).length;
+
+  console.log(`\n${b(path.relative(ROOT, file))}  ${d(`(${formatFileSummary(known, unknown)})`)}`);
+  console.log(DIVIDER_THIN);
+
+  for (const hit of hits) printHit(hit, showAst);
+
+  return { known, unknown };
+}
+
+function printSummary(totalKnown, totalUnknown) {
+  console.log(DIVIDER_THICK);
+  console.log(b('[ 결과 요약 ]'));
+  console.log(`  ${g('[KNOWN]')}   테마 색상이 하드코딩된 곳: ${g(b(totalKnown + '건'))}  → 토큰으로 교체 필요`);
+  console.log(`  ${y('[UNKNOWN]')} 테마에 없는 색상:           ${y(b(totalUnknown + '건'))}  → 신규 토큰 추가 검토`);
+  console.log(DIVIDER_THICK);
+  console.log(d('\nTip: --ast 플래그로 원시 AST 노드 구조를 함께 볼 수 있습니다.'));
+  console.log(d('     --file src/... 로 특정 파일만 볼 수 있습니다.\n'));
+}
+
+// ─── 메인 ────────────────────────────────────────────────────────────────────
+
+const { fileArg, outputArg, showAst, onlyKnown, onlyUnknown } = parseArgs(process.argv);
+
+setupFileOutput(outputArg);
+
+const tokenMap = extractThemeColorMap(THEME_FILE);
+printTokenMap(tokenMap);
+
+const files = resolveTargetFiles(fileArg);
+console.log(b(`\n▶ ${files.length}개 파일 스캔 중...`));
+console.log(DIVIDER_THIN);
+
+let totalKnown = 0;
+let totalUnknown = 0;
+
+for (const file of files) {
+  const rawHits = scanFile(file, tokenMap, ROOT);
+  const hits = filterHits(rawHits, { onlyKnown, onlyUnknown });
+  if (hits.length === 0) continue;
+
+  const { known, unknown } = printFileHits(file, hits, showAst);
+  totalKnown += known;
+  totalUnknown += unknown;
+}
+
+printSummary(totalKnown, totalUnknown);

--- a/apps/web/scripts/analyzeDesign/lib/reporter.mjs
+++ b/apps/web/scripts/analyzeDesign/lib/reporter.mjs
@@ -1,0 +1,45 @@
+import { b, r, y, g, cy, d, m } from '../../lib/ansi.mjs';
+
+function renderAstNode(node, indent = 0) {
+  if (!node || typeof node !== 'object') return;
+  const pad = '  '.repeat(indent);
+  const loc = node.loc ? d(` [${node.loc.start.line}:${node.loc.start.column}]`) : '';
+  let label = cy(node.type) + loc;
+
+  if (node.type === 'Identifier') label += '  ' + b(node.name);
+  if (node.type === 'StringLiteral') label += '  ' + r(`"${node.value}"`);
+  if (node.type === 'NumericLiteral') label += '  ' + g(String(node.value));
+  console.log(`${pad}${label}`);
+
+  if (node.type === 'ObjectProperty') {
+    renderAstNode(node.key, indent + 1);
+    renderAstNode(node.value, indent + 1);
+  }
+  if (node.type === 'ObjectExpression') {
+    console.log(`${pad}  ${d(`{ ${node.properties.length}개 프로퍼티 }`)}`);
+  }
+}
+
+export function printHit(hit, showAst = false) {
+  const locLabel = d(`${String(hit.line).padStart(4)}:${String(hit.col).padStart(2)}`);
+  const kindLabel = hit.token ? g('[KNOWN]') : y('[UNKNOWN]');
+  const exportLabel = hit.exportName ? m(`  ← ${hit.exportName}`) : '';
+
+  console.log(
+    `  ${locLabel}  ${kindLabel}  ${cy(hit.propKey)}: ${r(`'${hit.rawValue}'`)}${exportLabel}`,
+  );
+  console.log(`${d('path:')} ${hit.parentTypes.join(' > ')} > ObjectProperty`);
+
+  if (hit.token) {
+    console.log(`${g('→ token:')} ${g(hit.token)}`);
+  } else {
+    console.log(`${y('→ 대응 토큰 없음')} (theme.css.ts에 없는 색상)`);
+  }
+
+  if (showAst) {
+    console.log(`${d('── AST ──')}`);
+    renderAstNode(hit.astNode, 4);
+  }
+
+  console.log();
+}

--- a/apps/web/scripts/analyzeDesign/lib/scanner.mjs
+++ b/apps/web/scripts/analyzeDesign/lib/scanner.mjs
@@ -1,0 +1,108 @@
+import _traverse from '@babel/traverse';
+import path from 'path';
+import { parseFile } from '../../lib/parse.mjs';
+import { CSS_NAMED_HEX, collectColor, normalizeColor } from '../../lib/color-utils.mjs';
+import { y } from '../../lib/ansi.mjs';
+
+const traverse = _traverse.default ?? _traverse;
+
+const MAX_PARENT_DEPTH = 5;
+
+export function scanFile(filePath, tokenMap, ROOT) {
+  let ast;
+  try {
+    ast = parseFile(filePath);
+  } catch (e) {
+    console.warn(`${y('PARSE ERROR')} ${path.relative(ROOT, filePath)}: ${e.message}`);
+    return [];
+  }
+
+  const hits = [];
+
+  traverse(ast, {
+    ObjectProperty(nodePath) {
+      const prop = extractStringProperty(nodePath.node);
+      if (!prop) return;
+
+      const hit = resolveColorHit(prop, tokenMap, nodePath);
+      if (hit) hits.push(hit);
+    },
+  });
+
+  return hits;
+}
+
+function extractStringProperty(node) {
+  if (node.value.type !== 'StringLiteral') return null;
+  const keyName = node.key.type === 'Identifier' ? node.key.name : node.key.value;
+  return { valueNode: node.value, keyName, raw: node.value.value };
+}
+
+function resolveColorHit({ valueNode, keyName, raw }, tokenMap, nodePath) {
+  const namedColorHit = resolveAsNamedColor(raw, tokenMap);
+  if (namedColorHit) {
+    return makeHit(valueNode, keyName, raw, namedColorHit.normalized, namedColorHit.token, 'NAMED', nodePath);
+  }
+
+  const hexColorHit = resolveAsHexColor(raw, tokenMap);
+  if (hexColorHit) {
+    return makeHit(valueNode, keyName, raw, hexColorHit.normalized, hexColorHit.token, 'COLOR', nodePath);
+  }
+
+  return null;
+}
+
+function resolveAsNamedColor(raw, tokenMap) {
+  const namedHex = CSS_NAMED_HEX.get(raw.toLowerCase());
+  if (!namedHex) return null;
+
+  const normalized = namedHex.toUpperCase();
+  return { normalized, token: tokenMap.get(normalized) ?? null };
+}
+
+function resolveAsHexColor(raw, tokenMap) {
+  if (!collectColor(raw)) return null;
+
+  const normalized = normalizeColor(raw);
+  return { normalized, token: tokenMap.get(normalized) ?? null };
+}
+
+function makeHit(valueNode, propKey, rawValue, normalized, token, kind, nodePath) {
+  return {
+    line: valueNode.loc.start.line,
+    col: valueNode.loc.start.column,
+    propKey,
+    rawValue,
+    normalized,
+    token,
+    kind,
+    astNode: nodePath.node,
+    parentTypes: collectParentTypes(nodePath),
+    exportName: findExportName(nodePath),
+  };
+}
+
+function collectParentTypes(nodePath) {
+  const chain = [];
+  let cur = nodePath.parentPath;
+  let depth = 0;
+  while (cur && depth < MAX_PARENT_DEPTH) {
+    chain.unshift(cur.node.type);
+    cur = cur.parentPath;
+    depth++;
+  }
+  return chain;
+}
+
+function isNamedDeclarator(node) {
+  return node.type === 'VariableDeclarator' && node.id?.type === 'Identifier';
+}
+
+function findExportName(nodePath) {
+  let cur = nodePath;
+  while (cur) {
+    if (isNamedDeclarator(cur.node)) return cur.node.id.name;
+    cur = cur.parentPath;
+  }
+  return null;
+}

--- a/apps/web/scripts/codemode/index.mjs
+++ b/apps/web/scripts/codemode/index.mjs
@@ -1,0 +1,110 @@
+/**
+ * Codemod: 하드코딩된 색상 → 디자인 토큰 교체
+ *
+ * @babel/generator 없이 AST의 node.start / node.end offset으로 해당 문자열만 교체합니다.
+ * → 불필요한 diff 없음, 포매팅 유지, lint 규칙 유지
+ *
+ * 대상: [KNOWN] 항목만 (theme.css.ts에 대응 토큰이 존재하는 것)
+ *
+ * 사용법:
+ *   node scripts/codemode/codemod-color-tokens.mjs                     → dry-run (기본)
+ *   node scripts/codemode/codemod-color-tokens.mjs --apply             → 실제 파일 수정
+ *   node scripts/codemode/codemod-color-tokens.mjs --file src/...      → 단일 파일
+ *   node scripts/codemode/codemod-color-tokens.mjs --file src/... --apply
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import { globSync } from 'glob';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { b, r, g, y, d } from '../lib/ansi.mjs';
+import { extractThemeColorMap } from '../lib/theme-parser.mjs';
+import { parseFile } from '../lib/parse.mjs';
+import { collectHits } from './lib/collector.mjs';
+import { buildReplacement, buildImportPatch, applyPatches } from './lib/transformer.mjs';
+import { printDiff } from './lib/reporter.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '../..');
+const THEME_FILE = path.resolve(ROOT, 'src/common/styles/theme.css.ts');
+
+// ─── CLI ─────────────────────────────────────────────────────────────────────
+const args = process.argv.slice(2);
+const fileArg = args.includes('--file') ? args[args.indexOf('--file') + 1] : null;
+const apply = args.includes('--apply');
+
+// ─── 메인 ────────────────────────────────────────────────────────────────────
+const tokenMap = extractThemeColorMap(THEME_FILE);
+console.log(`\n${b('▶ 디자인 토큰')} ${d(`${tokenMap.size}개 로드`)}`);
+
+if (!apply) {
+  console.log(
+    `${y('  dry-run 모드')} — 실제 파일은 변경되지 않습니다. 적용하려면 ${b(
+      '--apply',
+    )} 를 추가하세요.\n`,
+  );
+} else {
+  console.log(`${r('  --apply 모드')} — 파일을 실제로 수정합니다.\n`);
+}
+
+const files = fileArg
+  ? [path.isAbsolute(fileArg) ? fileArg : path.resolve(ROOT, fileArg)]
+  : globSync('src/**/*.{ts,tsx}', {
+      cwd: ROOT,
+      absolute: true,
+      ignore: ['**/node_modules/**', '**/.next/**', '**/theme.css.ts'],
+    });
+
+let totalFiles = 0;
+let totalHits = 0;
+
+for (const file of files) {
+  const source = readFileSync(file, 'utf-8');
+  let ast;
+  try {
+    ast = parseFile(file);
+  } catch {
+    console.warn(`${y('PARSE ERROR')} ${path.relative(ROOT, file)}`);
+    continue;
+  }
+
+  const hits = collectHits(ast, tokenMap);
+  if (hits.length === 0) continue;
+
+  const importPatch = buildImportPatch(ast);
+  const relPath = path.relative(ROOT, file);
+
+  printDiff(relPath, hits, importPatch, source);
+
+  totalFiles++;
+  totalHits += hits.length;
+
+  if (apply) {
+    const colorPatches = hits.map((hit) => ({
+      start: hit.node.start,
+      end: hit.node.end,
+      text: buildReplacement(hit.rawValue, hit.token),
+    }));
+    const allPatches = importPatch ? [...colorPatches, importPatch] : colorPatches;
+    writeFileSync(file, applyPatches(source, allPatches), 'utf-8');
+    console.log(`  ${g('✓ 저장됨')}\n`);
+  }
+}
+
+// ─── 요약 ────────────────────────────────────────────────────────────────────
+console.log('═'.repeat(64));
+console.log(b('[ 결과 요약 ]'));
+console.log(`  대상 파일: ${b(totalFiles + '개')}`);
+console.log(`  교체 항목: ${b(totalHits + '건')}`);
+if (!apply) {
+  console.log(
+    `\n  ${y('→ 실제 적용하려면:')} ${b('node scripts/codemode/codemod-color-tokens.mjs --apply')}`,
+  );
+  console.log(
+    `  ${y('→ 단일 파일 적용:')} ${b(
+      'node scripts/codemode/codemod-color-tokens.mjs --file src/... --apply',
+    )}`,
+  );
+}
+console.log('═'.repeat(64));

--- a/apps/web/scripts/codemode/index.mjs
+++ b/apps/web/scripts/codemode/index.mjs
@@ -7,10 +7,10 @@
  * 대상: [KNOWN] 항목만 (theme.css.ts에 대응 토큰이 존재하는 것)
  *
  * 사용법:
- *   node scripts/codemode/codemod-color-tokens.mjs                     → dry-run (기본)
- *   node scripts/codemode/codemod-color-tokens.mjs --apply             → 실제 파일 수정
- *   node scripts/codemode/codemod-color-tokens.mjs --file src/...      → 단일 파일
- *   node scripts/codemode/codemod-color-tokens.mjs --file src/... --apply
++ *   node scripts/codemode/index.mjs                     → dry-run (기본)
++ *   node scripts/codemode/index.mjs --apply             → 실제 파일 수정
++ *   node scripts/codemode/index.mjs --file src/...      → 단일 파일
++ *   node scripts/codemode/index.mjs --file src/... --apply
  */
 
 import { readFileSync, writeFileSync } from 'fs';

--- a/apps/web/scripts/codemode/lib/collector.mjs
+++ b/apps/web/scripts/codemode/lib/collector.mjs
@@ -1,0 +1,33 @@
+import _traverse from '@babel/traverse';
+import { CSS_NAMED_HEX, collectColor, normalizeColor } from '../../lib/color-utils.mjs';
+
+const traverse = _traverse.default ?? _traverse;
+
+export function collectHits(ast, tokenMap) {
+  const hits = [];
+
+  traverse(ast, {
+    ObjectProperty(p) {
+      const { value } = p.node;
+      if (value.type !== 'StringLiteral') return;
+
+      const raw = value.value;
+      const namedHex = CSS_NAMED_HEX.get(raw.toLowerCase());
+
+      if (namedHex) {
+        const token = tokenMap.get(namedHex);
+        if (!token) return;
+        hits.push({ node: value, token, rawValue: raw, line: value.loc.start.line });
+        return;
+      }
+
+      if (!collectColor(raw)) return;
+      const token = tokenMap.get(normalizeColor(raw));
+      if (!token) return;
+
+      hits.push({ node: value, token, rawValue: raw, line: value.loc.start.line });
+    },
+  });
+
+  return hits;
+}

--- a/apps/web/scripts/codemode/lib/reporter.mjs
+++ b/apps/web/scripts/codemode/lib/reporter.mjs
@@ -1,0 +1,23 @@
+import { b, r, g, y, d } from '../../lib/ansi.mjs';
+import { buildReplacement } from './transformer.mjs';
+
+export function printDiff(relPath, hits, importPatch, source) {
+  const lines = source.split('\n');
+
+  console.log(`\n${b(relPath)}`);
+  console.log('─'.repeat(64));
+
+  if (importPatch) {
+    const importLine = source.slice(0, importPatch.start).split('\n').length;
+    console.log(`  ${d(`line ${importLine}`)}  ${y('[import 추가]')}  ${g('+vars')}`);
+  }
+
+  for (const hit of hits) {
+    const repl = buildReplacement(hit.rawValue, hit.token);
+    const orig = lines[hit.line - 1]?.trim() ?? '';
+    console.log(`  ${d(`line ${hit.line}`)}  ${r(`- '${hit.rawValue}'`)}`);
+    console.log(`  ${d('       ')}  ${g(`+ ${repl}`)}`);
+    console.log(`  ${d('       ')}  ${d(`context: ${orig}`)}`);
+    console.log();
+  }
+}

--- a/apps/web/scripts/codemode/lib/transformer.mjs
+++ b/apps/web/scripts/codemode/lib/transformer.mjs
@@ -13,17 +13,25 @@ export function buildImportPatch(ast) {
   for (const node of ast.program.body) {
     if (node.type !== 'ImportDeclaration') continue;
     lastImportEnd = node.end;
-    if (!node.source.value.includes('theme.css')) continue;
+    if (node.source.value !== THEME_IMPORT_SOURCE) continue;
     themeImportNode = node;
-    hasVars = node.specifiers.some((s) => s.type === 'ImportSpecifier' && s.local.name === 'vars');
+    hasVars = node.specifiers.some(
+      (s) => s.type === 'ImportSpecifier' && s.imported?.name === 'vars',
+    );
   }
 
   if (hasVars) return null;
 
   if (themeImportNode) {
-    const firstSpec = themeImportNode.specifiers[0];
-    if (!firstSpec) return null;
-    return { start: firstSpec.start, end: firstSpec.start, text: 'vars, ' };
+    const firstNamedSpec = themeImportNode.specifiers.find((s) => s.type === 'ImportSpecifier');
+    if (firstNamedSpec) {
+      return { start: firstNamedSpec.start, end: firstNamedSpec.start, text: 'vars, ' };
+    }
+    return {
+      start: themeImportNode.end,
+      end: themeImportNode.end,
+      text: `\nimport { vars } from '${THEME_IMPORT_SOURCE}';`,
+    };
   }
 
   return {

--- a/apps/web/scripts/codemode/lib/transformer.mjs
+++ b/apps/web/scripts/codemode/lib/transformer.mjs
@@ -1,0 +1,45 @@
+const THEME_IMPORT_SOURCE = '@/common/styles/theme.css';
+
+export function buildReplacement(rawValue, token) {
+  if (/!important/i.test(rawValue)) return `\`\${${token}} !important\``;
+  return token;
+}
+
+export function buildImportPatch(ast) {
+  let themeImportNode = null;
+  let hasVars = false;
+  let lastImportEnd = 0;
+
+  for (const node of ast.program.body) {
+    if (node.type !== 'ImportDeclaration') continue;
+    lastImportEnd = node.end;
+    if (!node.source.value.includes('theme.css')) continue;
+    themeImportNode = node;
+    hasVars = node.specifiers.some((s) => s.type === 'ImportSpecifier' && s.local.name === 'vars');
+  }
+
+  if (hasVars) return null;
+
+  if (themeImportNode) {
+    const firstSpec = themeImportNode.specifiers[0];
+    if (!firstSpec) return null;
+    return { start: firstSpec.start, end: firstSpec.start, text: 'vars, ' };
+  }
+
+  return {
+    start: lastImportEnd,
+    end: lastImportEnd,
+    text: `\nimport { vars } from '${THEME_IMPORT_SOURCE}';`,
+  };
+}
+
+/**
+ * offset 기반 패치를 뒤에서부터 적용해 앞 offset이 흔들리지 않도록 합니다.
+ */
+export function applyPatches(source, patches) {
+  const sorted = [...patches].sort((a, b) => b.start - a.start);
+  return sorted.reduce(
+    (src, { start, end, text }) => src.slice(0, start) + text + src.slice(end),
+    source,
+  );
+}

--- a/apps/web/scripts/lib/ansi.mjs
+++ b/apps/web/scripts/lib/ansi.mjs
@@ -1,0 +1,21 @@
+export const C = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  red: '\x1b[31m',
+  yellow: '\x1b[33m',
+  cyan: '\x1b[36m',
+  green: '\x1b[32m',
+  magenta: '\x1b[35m',
+  gray: '\x1b[90m',
+};
+
+export const b = (s) => `${C.bold}${s}${C.reset}`;
+export const r = (s) => `${C.red}${s}${C.reset}`;
+export const y = (s) => `${C.yellow}${s}${C.reset}`;
+export const g = (s) => `${C.green}${s}${C.reset}`;
+export const cy = (s) => `${C.cyan}${s}${C.reset}`;
+export const d = (s) => `${C.dim}${s}${C.reset}`;
+export const m = (s) => `${C.magenta}${s}${C.reset}`;
+
+export const ANSI_RE = /\x1b\[[0-9;]*m/g;

--- a/apps/web/scripts/lib/color-utils.mjs
+++ b/apps/web/scripts/lib/color-utils.mjs
@@ -1,0 +1,30 @@
+export const CSS_NAMED_HEX = new Map([
+  ['white', '#FFFFFF'],
+  ['black', '#000000'],
+  ['transparent', 'transparent'],
+]);
+
+const COLOR_PATTERNS = [
+  { re: /^#([0-9a-fA-F]{3,8})(\s*!important)?\s*$/ },
+  { re: /^rgba?\s*\(/i },
+  { re: /^hsla?\s*\(/i },
+];
+
+export function collectColor(value) {
+  const v = value.trim();
+  return COLOR_PATTERNS.some((p) => p.re.test(v));
+}
+
+export function normalizeColor(raw) {
+  let v = raw
+    .trim()
+    .replace(/\s*!important\s*$/i, '')
+    .trim()
+    .toUpperCase();
+  // 약식 hex #ABC → #AABBCC
+  if (/^#([0-9A-F]{3})$/.test(v)) {
+    const [, h] = v.match(/^#([0-9A-F]{3})$/);
+    v = '#' + h.split('').map((c) => c + c).join('');
+  }
+  return v;
+}

--- a/apps/web/scripts/lib/parse.mjs
+++ b/apps/web/scripts/lib/parse.mjs
@@ -1,0 +1,10 @@
+import { parse } from '@babel/parser';
+import { readFileSync } from 'fs';
+
+export function parseFile(filePath) {
+  const code = readFileSync(filePath, 'utf-8');
+  return parse(code, {
+    sourceType: 'module',
+    plugins: ['typescript', 'jsx'],
+  });
+}

--- a/apps/web/scripts/lib/theme-parser.mjs
+++ b/apps/web/scripts/lib/theme-parser.mjs
@@ -1,0 +1,70 @@
+import _traverse from '@babel/traverse';
+import { parseFile } from './parse.mjs';
+
+const traverse = _traverse.default ?? _traverse;
+
+function isCreateGlobalTheme(callNode) {
+  const callee = callNode.callee;
+  return callee.type === 'Identifier' && callee.name === 'createGlobalTheme';
+}
+
+function isColorsKey(key) {
+  return (
+    (key.type === 'Identifier' && key.name === 'colors') ||
+    (key.type === 'StringLiteral' && key.value === 'colors')
+  );
+}
+
+function buildTokenPath(pathParts) {
+  return 'vars.colors.' + pathParts.join('.');
+}
+
+function extractColorsNode(callNode) {
+  const themeArg = callNode.arguments[2];
+  if (!themeArg || themeArg.type !== 'ObjectExpression') return null;
+
+  const colorsProp = themeArg.properties.find((p) => isColorsKey(p.key));
+
+  return colorsProp?.value?.type === 'ObjectExpression' ? colorsProp.value : null;
+}
+
+function collectColorTokens(objNode, ancestorPath, tokenMap) {
+  for (const prop of objNode.properties) {
+    if (prop.type !== 'ObjectProperty') continue;
+
+    const key = prop.key.type === 'Identifier' ? prop.key.name : prop.key.value;
+    const currentPath = [...ancestorPath, key];
+
+    if (prop.value.type === 'StringLiteral') {
+      const hexValue = prop.value.value.trim().toUpperCase();
+      tokenMap.set(hexValue, buildTokenPath(currentPath));
+    } else if (prop.value.type === 'ObjectExpression') {
+      collectColorTokens(prop.value, currentPath, tokenMap);
+    }
+  }
+}
+
+export function extractThemeColorMap(themeFilePath) {
+  const tokenMap = new Map();
+
+  let ast;
+  try {
+    ast = parseFile(themeFilePath);
+  } catch (e) {
+    console.error(`theme.css.ts 파싱 실패: ${e.message}`);
+    process.exit(1);
+  }
+
+  traverse(ast, {
+    CallExpression(nodePath) {
+      if (!isCreateGlobalTheme(nodePath.node)) return;
+
+      const colorsNode = extractColorsNode(nodePath.node);
+      if (!colorsNode) return;
+
+      collectColorTokens(colorsNode, /* ancestorPath= */ [], tokenMap);
+    },
+  });
+
+  return tokenMap;
+}

--- a/apps/web/scripts/lib/theme-parser.mjs
+++ b/apps/web/scripts/lib/theme-parser.mjs
@@ -23,7 +23,11 @@ function extractColorsNode(callNode) {
   const themeArg = callNode.arguments[2];
   if (!themeArg || themeArg.type !== 'ObjectExpression') return null;
 
-  const colorsProp = themeArg.properties.find((p) => isColorsKey(p.key));
+  const colorsProp = themeArg.properties.find(
+    (p) =>
+      p.type === 'ObjectProperty' &&
+      isColorsKey(p.key.type === 'Identifier' ? p.key.name : p.key.value),
+  );
 
   return colorsProp?.value?.type === 'ObjectExpression' ? colorsProp.value : null;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,15 @@ importers:
         specifier: ^5.0.6
         version: 5.0.9(@types/react@19.2.7)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     devDependencies:
+      '@babel/parser':
+        specifier: ^7.29.3
+        version: 7.29.3
+      '@babel/traverse':
+        specifier: ^7.29.0
+        version: 7.29.0
+      '@babel/types':
+        specifier: ^7.29.0
+        version: 7.29.0
       '@eslint/eslintrc':
         specifier: ^3
         version: 3.3.3
@@ -144,6 +153,9 @@ importers:
       eslint-config-next:
         specifier: ^15.5.7
         version: 15.5.9(eslint@9.39.2)(typescript@5.9.3)
+      glob:
+        specifier: ^13.0.6
+        version: 13.0.6
       msw:
         specifier: ^2.10.1
         version: 2.12.7(@types/node@20.19.27)(typescript@5.9.3)
@@ -572,6 +584,10 @@ packages:
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.28.5':
     resolution: {integrity: sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==}
     engines: {node: '>=6.9.0'}
@@ -582,6 +598,10 @@ packages:
 
   '@babel/generator@7.28.5':
     resolution: {integrity: sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.27.3':
@@ -673,6 +693,11 @@ packages:
 
   '@babel/parser@7.28.5':
     resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1127,12 +1152,24 @@ packages:
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/traverse@7.28.5':
     resolution: {integrity: sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.28.5':
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -4189,6 +4226,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   baseline-browser-mapping@2.9.11:
     resolution: {integrity: sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==}
     hasBin: true
@@ -4220,6 +4261,10 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -5250,16 +5295,22 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -5969,6 +6020,10 @@ packages:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -5985,6 +6040,10 @@ packages:
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   mixpanel@0.13.0:
@@ -6274,6 +6333,10 @@ packages:
   path-scurry@2.0.1:
     resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
     engines: {node: 20 || >=22}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -8934,6 +8997,12 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.28.5': {}
 
   '@babel/core@7.28.5':
@@ -8943,10 +9012,10 @@ snapshots:
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
       '@babel/helpers': 7.28.4
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.3
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -8958,15 +9027,23 @@ snapshots:
 
   '@babel/generator@7.28.5':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/helper-compilation-targets@7.27.2':
     dependencies:
@@ -8984,7 +9061,7 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -9011,15 +9088,15 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9028,13 +9105,13 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/helper-plugin-utils@7.27.1': {}
 
@@ -9043,7 +9120,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.28.3
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9052,14 +9129,14 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9072,25 +9149,29 @@ snapshots:
   '@babel/helper-wrap-function@7.28.3':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helpers@7.28.4':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/parser@7.28.5':
     dependencies:
       '@babel/types': 7.28.5
 
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9117,7 +9198,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9161,7 +9242,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9208,7 +9289,7 @@ snapshots:
       '@babel/helper-globals': 7.28.0
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9222,7 +9303,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9279,7 +9360,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9325,7 +9406,7 @@ snapshots:
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9365,7 +9446,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5)
       '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.5)
-      '@babel/traverse': 7.28.5
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9451,7 +9532,7 @@ snapshots:
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9619,7 +9700,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
       esutils: 2.0.3
 
   '@babel/preset-react@7.28.5(@babel/core@7.28.5)':
@@ -9650,8 +9731,14 @@ snapshots:
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
 
   '@babel/traverse@7.28.5':
     dependencies:
@@ -9665,7 +9752,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.28.5':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
@@ -12087,7 +12191,7 @@ snapshots:
 
   '@svgr/hast-util-to-babel-ast@8.0.0':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
       entities: 4.5.0
 
   '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
@@ -12140,7 +12244,7 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       '@babel/runtime': 7.28.4
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
@@ -12884,7 +12988,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.26':
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.3
       '@vue/shared': 3.5.26
       entities: 7.0.0
       estree-walker: 2.0.2
@@ -12897,7 +13001,7 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.26':
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.3
       '@vue/compiler-core': 3.5.26
       '@vue/compiler-dom': 3.5.26
       '@vue/compiler-ssr': 3.5.26
@@ -13385,6 +13489,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   baseline-browser-mapping@2.9.11: {}
 
   big.js@5.2.2: {}
@@ -13412,6 +13518,10 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -14669,6 +14779,12 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.1
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -15374,6 +15490,10 @@ snapshots:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
@@ -15389,6 +15509,8 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.2: {}
+
+  minipass@7.1.3: {}
 
   mixpanel@0.13.0:
     dependencies:
@@ -15559,11 +15681,11 @@ snapshots:
 
   node-source-walk@6.0.2:
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.3
 
   node-source-walk@7.0.1:
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.3
 
   normalize-path@3.0.0: {}
 
@@ -15733,6 +15855,11 @@ snapshots:
     dependencies:
       lru-cache: 11.2.4
       minipass: 7.1.2
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.2.4
+      minipass: 7.1.3
 
   path-to-regexp@6.3.0: {}
 


### PR DESCRIPTION
### 작업 내용
디자인 시스템의 색상을 감지하여 사용량을 분석하는 CLI도구를 추가했어요.

### 1. 디자인 시스템 색상 분석(pnpm run analyze:design)

- 하드코딩된 색상값을 감지하기 위해 `@babel/parser` + `@babel/traverse`로 AST를 직접 분석하는 방식을 선택했습니다. 

<img width="630" height="166" alt="image" src="https://github.com/user-attachments/assets/49554ab6-316f-4d32-b9bf-34685b51f2e0" />

- `analyzeDesign` 스크립트는 dry-run 전용으로, `theme.css.ts`에서 색상 토큰 맵을 추출한 뒤 소스 파일을 순회하며 KNOWN(토큰 대응 가능) / UNKNOWN(신규 토큰 추가 필요) 항목을 구분해 보고합니다.
<img width="729" height="145" alt="image" src="https://github.com/user-attachments/assets/985410e3-76dc-41de-a7bf-c19c5bcce81c" />

### 2. codemod 기반 색상 교체(pnpm run codemod / codemod:apply)

`pnpm run codemod` — 교체 예정 목록 미리보기
`pnpm run codemod:apply` — 실제 파일 수정

- `codemod` 스크립트는 `@babel/generator` 없이 AST의 `node.start` / `node.end` 오프셋으로 문자열만 교체합니다. 이렇게 하면 불필요한 포맷팅 diff 없이 lint 규칙을 그대로 유지할 수 있습니다.
- `--apply` 플래그 없이는 파일이 변경되지 않는 dry-run이 기본이라, 실수로 전체 파일을 수정할 위험이 없습니다.

### 동작 원리

```
소스 코드 (.tsx)
     ↓  @babel/parser (파싱)
   AST (트리 구조)
     ↓  @babel/traverse (탐색)
  노드 방문(ObjectProperty)
     ↓
  지표 집계
```

### 리뷰어 확인 포인트
`import { vars }` 자동 삽입 로직(`buildImportPatch`)이 기존 theme import가 없는 파일도 처리하는지

### 연관 이슈

close #302
