### PR TITLE
하드코딩 hex 색상값을 디자인 토큰으로 교체(issue #304)

### DIFF
--- a/apps/web/src/common/components/dropdown/dropdown.css.ts
+++ b/apps/web/src/common/components/dropdown/dropdown.css.ts
@@ -1,4 +1,5 @@
 import { style } from '@vanilla-extract/css';
+import { vars } from '@/common/styles/theme.css';
 
 export const container = style({
   position: 'relative',
@@ -20,7 +21,7 @@ export const icon = style({
 export const panel = style({
   position: 'absolute',
   right: 0,
-  backgroundColor: '#fff',
+  backgroundColor: vars.colors.white,
   boxShadow: '0 0 10px rgba(0, 0, 0, 0.1)',
   borderRadius: '8px',
   zIndex: 100,

--- a/apps/web/src/common/components/header/adminHeader/adminHeader.css.ts
+++ b/apps/web/src/common/components/header/adminHeader/adminHeader.css.ts
@@ -115,7 +115,7 @@ export const RightArea = style({
 export const RightAreaIcon = style({
   width: '20px',
   height: '20px',
-  backgroundColor: '#A5BDF5',
+  backgroundColor: vars.colors.primary.fixed_dim,
   borderRadius: '50%',
 });
 

--- a/apps/web/src/common/components/header/clientHeader/clientHeader.css.ts
+++ b/apps/web/src/common/components/header/clientHeader/clientHeader.css.ts
@@ -205,5 +205,5 @@ export const PersonWrapper = style({
 export const Nametext = style({
   fontSize: vars.fonts.body2,
   fontWeight: 700,
-  color: 'white',
+  color: vars.colors.white,
 });

--- a/apps/web/src/common/ui/button/button.css.ts
+++ b/apps/web/src/common/ui/button/button.css.ts
@@ -29,7 +29,7 @@ export const buttonStyle = styleVariants({
   },
   danger: {
     backgroundColor: vars.colors.error.base,
-    color: '#BE3439',
+    color: vars.colors.error.primary,
   },
   none: {},
 });

--- a/apps/web/src/common/ui/dropdownButton/dropdownButton.css.ts
+++ b/apps/web/src/common/ui/dropdownButton/dropdownButton.css.ts
@@ -10,7 +10,7 @@ export const dropDownButtonStyle = styleVariants({
   error: {
     backgroundColor: vars.colors.error.base,
     border: `1px solid ${vars.colors.error.container}`,
-    color: '#BE3439',
+    color: vars.colors.error.primary,
   },
   tertiary: {
     backgroundColor: vars.colors.tertiary.base,

--- a/apps/web/src/components/404/index.css.ts
+++ b/apps/web/src/components/404/index.css.ts
@@ -1,5 +1,6 @@
 import { style } from '@vanilla-extract/css';
 import { BREAKPOINTS } from '@/common/constants';
+import { vars } from '@/common/styles/theme.css';
 
 export const wrapper = style({
   minHeight: '90vh',
@@ -7,7 +8,7 @@ export const wrapper = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  backgroundColor: '#F5F5F6',
+  backgroundColor: vars.colors.surface.variant,
 
   '@media': {
     [`screen and (max-width: ${BREAKPOINTS.desktop}px)`]: {
@@ -23,7 +24,7 @@ export const container = style({
   justifyContent: 'center',
   padding: '54px 40px 70px 40px',
   borderRadius: '8px',
-  backgroundColor: 'white',
+  backgroundColor: vars.colors.white,
   gap: '16px',
   width: '500px',
 
@@ -59,7 +60,7 @@ export const stringTextContainer = style({
 export const stringText = style({
   fontSize: '23px',
   fontWeight: '600',
-  color: '#272E3B',
+  color: vars.colors.charcoal,
 
   '@media': {
     [`screen and (max-width: ${BREAKPOINTS.desktop}px)`]: {

--- a/apps/web/src/components/admin/applicants/applicantDetailModal/applicantDetailModal.css.ts
+++ b/apps/web/src/components/admin/applicants/applicantDetailModal/applicantDetailModal.css.ts
@@ -44,7 +44,7 @@ export const header = style({
   borderTopRightRadius: '8px',
   '@media': {
     [`screen and (max-width: ${BREAKPOINTS.desktop - 1}px)`]: {
-      backgroundColor: '#F5F5F6',
+      backgroundColor: vars.colors.surface.variant,
       height: '55px',
       padding: '0 20px',
     },

--- a/apps/web/src/components/admin/applicationForm/createform/createform.css.ts
+++ b/apps/web/src/components/admin/applicationForm/createform/createform.css.ts
@@ -170,7 +170,7 @@ export const Title = style({
 export const descriptionInBox = style({
   fontSize: vars.fonts.title4,
   fontWeight: 500,
-  color: '#5A6379',
+  color: vars.colors.surface.outline,
   textAlign: 'center',
   marginTop: '10px',
   marginBottom: '32px',

--- a/apps/web/src/components/admin/applicationForm/questionForm/questionFrom.css.ts
+++ b/apps/web/src/components/admin/applicationForm/questionForm/questionFrom.css.ts
@@ -15,7 +15,7 @@ export const container = style({
   width: '100%',
   '@media': {
     [`screen and (max-width: ${BREAKPOINTS.desktop - 1}px)`]: {
-      backgroundColor: '#f5f5f6',
+      backgroundColor: vars.colors.surface.variant,
       padding: '0',
     },
   },
@@ -126,7 +126,7 @@ export const formFeildBlock = style({
   '@media': {
     [`screen and (max-width: ${BREAKPOINTS.desktop - 1}px)`]: {
       padding: '0px 14px 14px 14px',
-      backgroundColor: '#ffffff',
+      backgroundColor: vars.colors.white,
     },
   },
 });
@@ -382,7 +382,7 @@ export const applicantInfoField = style({
   '@media': {
     [`screen and (max-width: ${BREAKPOINTS.desktop - 1}px)`]: {
       padding: '16px 14px',
-      backgroundColor: '#ffffff',
+      backgroundColor: vars.colors.white,
       marginBottom: '80px',
     },
   },
@@ -403,7 +403,7 @@ export const applicantInfoInput = style({
   '@media': {
     [`screen and (max-width: ${BREAKPOINTS.desktop - 1}px)`]: {
       padding: '10px 12px',
-      backgroundColor: '#F8F8F9 !important',
+      backgroundColor: `${vars.colors.surface.default} !important`,
       fontSize: vars.fonts.m_body1,
     },
   },

--- a/apps/web/src/components/admin/clubInfo/RightSideBar.css.ts
+++ b/apps/web/src/components/admin/clubInfo/RightSideBar.css.ts
@@ -20,7 +20,7 @@ export const container = style({
 });
 
 export const contentBox = style({
-  background: 'white',
+  background: vars.colors.white,
   borderRadius: '8px',
   padding: '24px 26px',
   marginBottom: '20px',
@@ -56,7 +56,7 @@ export const grayText = style({
 });
 
 export const blackText = style({
-  color: '#030304',
+  color: vars.colors.surface.on_surf,
   fontSize: vars.fonts.body1,
   fontWeight: 500,
 

--- a/apps/web/src/components/admin/clubInfo/clubBox.css.ts
+++ b/apps/web/src/components/admin/clubInfo/clubBox.css.ts
@@ -7,7 +7,7 @@ export const container = style({
   flex: '1 0 0',
   borderRadius: '8px',
   padding: '18px 24px',
-  backgroundColor: 'white',
+  backgroundColor: vars.colors.white,
   // marginBottom: '28px',
 
   minWidth: 0,
@@ -136,7 +136,7 @@ export const dropDownStyleWide = style({
 export const dropDownStyle2 = style({
   padding: '6px 0 6px 8px',
   borderRadius: '4px',
-  backgroundColor: '#E7E8EA',
+  backgroundColor: vars.colors.surface.cont_2,
   color: '#55637D',
   // minWidth: '80px',
   // width: '80px',
@@ -152,7 +152,7 @@ export const dropDownStyle2 = style({
 export const dropDownStyle2Wide = style({
   padding: '6px 0 6px 8px',
   borderRadius: '4px',
-  backgroundColor: '#F8F8F9',
+  backgroundColor: vars.colors.surface.default,
   color: '#55637D',
 
   width: '115px',
@@ -164,7 +164,7 @@ export const dropdownPanel = style({
   left: 0,
   // minWidth: '80px',
   width: '100%',
-  background: '#f8f8f9',
+  background: vars.colors.surface.default,
   border: '1px solid #e7e8ea',
   borderRadius: '4px',
   boxShadow: '0 2px 8px rgba(0,0,0,0.04)',
@@ -178,7 +178,7 @@ export const dropdownItem = style({
   fontFamily: 'Pretendard Variable',
   fontWeight: 500,
   fontSize: '16px',
-  color: '#5a6379',
+  color: vars.colors.surface.outline,
   cursor: 'pointer',
   transition: 'background 0.15s',
   selectors: {
@@ -189,7 +189,7 @@ export const dropdownItem = style({
 });
 
 export const selectedDropdownItem = style({
-  background: '#e7e8ea',
+  background: vars.colors.surface.cont_2,
   color: '#2d3648',
 });
 
@@ -199,7 +199,7 @@ export const categoryDropdownPanel = style({
   left: 0,
   minWidth: '94px',
   width: '94px',
-  background: '#fff',
+  background: vars.colors.white,
   borderRadius: '8px',
   boxShadow: '0 2px 8px rgba(0,0,0,0.04)',
   zIndex: 10,
@@ -215,19 +215,19 @@ export const categoryDropdownItem = style({
   fontFamily: 'Pretendard Variable',
   fontWeight: 600,
   fontSize: '16px',
-  color: '#292e39',
+  color: vars.colors.surface.on_surf_var,
   cursor: 'pointer',
   transition: 'background 0.15s',
   selectors: {
     '&:hover': {
-      background: '#f8f8f9',
+      background: vars.colors.surface.default,
     },
   },
 });
 
 export const selectedCategoryDropdownItem = style({
-  background: '#e7e8ea',
-  color: '#292e39',
+  background: vars.colors.surface.cont_2,
+  color: vars.colors.surface.on_surf_var,
 });
 
 export const recruitDropdownPanel = style({
@@ -236,7 +236,7 @@ export const recruitDropdownPanel = style({
   left: 0,
   minWidth: '80px',
   width: '80px',
-  background: '#fff',
+  background: vars.colors.white,
   borderRadius: '8px',
   boxShadow: '0 2px 8px rgba(0,0,0,0.04)',
   zIndex: 10,
@@ -252,25 +252,25 @@ export const recruitDropdownItem = style({
   fontFamily: 'Pretendard Variable',
   fontWeight: 600,
   fontSize: '16px',
-  color: '#292e39',
+  color: vars.colors.surface.on_surf_var,
   cursor: 'pointer',
   transition: 'background 0.15s',
   selectors: {
     '&:hover': {
-      background: '#f8f8f9',
+      background: vars.colors.surface.default,
     },
   },
 });
 
 export const selectedRecruitDropdownItem = style({
-  background: '#e7e8ea',
-  color: '#292e39',
+  background: vars.colors.surface.cont_2,
+  color: vars.colors.surface.on_surf_var,
 });
 
 export const userInputTag = style({
   display: 'flex',
   alignItems: 'center',
-  background: '#f8f8f9',
+  background: vars.colors.surface.default,
   border: '1px solid #e7e8ea',
   borderRadius: '100px',
   padding: '4px 8px 4px 12px',
@@ -306,7 +306,7 @@ export const customFieldInput = style({
   fontSize: 16,
   fontWeight: 600,
   fontFamily: 'Pretendard Variable',
-  color: '#5a6379',
+  color: vars.colors.surface.outline,
   textAlign: 'center',
   outline: 'none',
   padding: 0,
@@ -327,7 +327,7 @@ export const customFieldSpan = style({
 export const customFieldText = style({
   fontWeight: 600,
   fontSize: 16,
-  color: '#5a6379',
+  color: vars.colors.surface.outline,
   lineHeight: '24px',
   textAlign: 'center',
   // whiteSpace: 'nowrap',
@@ -442,7 +442,7 @@ export const panelItem = style({
 
 export const panelItem2 = style({
   padding: '12px 0',
-  color: '#272E3B',
+  color: vars.colors.charcoal,
   fontSize: vars.fonts.body2,
   fontWeight: 600,
   cursor: 'pointer',
@@ -472,7 +472,7 @@ export const detailFlex = style({
   alignItems: 'center',
   borderRadius: '100px',
   padding: '4px 8px 4px 12px',
-  backgroundColor: '#F8F8F9',
+  backgroundColor: vars.colors.surface.default,
   border: '1px solid #E7E8EA',
 });
 export const detailInput = style({
@@ -487,7 +487,7 @@ export const detailInput = style({
 export const divider = style({
   display: 'none',
   height: '1px',
-  backgroundColor: '#EDEEF1',
+  backgroundColor: vars.colors.surface.cont_1_var,
   marginBottom: '14px',
 
   '@media': {

--- a/apps/web/src/components/admin/clubInfo/mdEditor.css.ts
+++ b/apps/web/src/components/admin/clubInfo/mdEditor.css.ts
@@ -37,7 +37,7 @@ export const buttonNotice = style({
   width: '50%',
   textAlign: 'center',
   padding: '22px 0',
-  backgroundColor: '#EEEEF0 !important',
+  backgroundColor: `${vars.colors.surface.cont_1} !important`,
   borderRadius: '6px 6px 0px 0px',
   color: '#55637D !important',
   fontSize: vars.fonts.body2,

--- a/apps/web/src/components/admin/clubMember/clubMemberAdd/form.css.ts
+++ b/apps/web/src/components/admin/clubMember/clubMemberAdd/form.css.ts
@@ -8,7 +8,7 @@ export const container = style({
   gap: '20px',
   borderRadius: '10px',
   padding: '20px 16px 16px 16px',
-  backgroundColor: 'white',
+  backgroundColor: vars.colors.white,
   marginBottom: '276px',
 
   '@media': {
@@ -21,7 +21,7 @@ export const container = style({
 export const title = style({
   fontSize: vars.fonts.title4,
   fontWeight: '600',
-  color: '#030304',
+  color: vars.colors.surface.on_surf,
 
   [`@media`]: {
     [`screen and (max-width: ${BREAKPOINTS.desktop}px)`]: {

--- a/apps/web/src/components/admin/clubMember/clubMemberAdd/header.css.ts
+++ b/apps/web/src/components/admin/clubMember/clubMemberAdd/header.css.ts
@@ -20,7 +20,7 @@ export const container = style({
 export const titleText = style({
   fontSize: vars.fonts.title2,
   fontWeight: '600',
-  color: '#030304',
+  color: vars.colors.surface.on_surf,
 
   [`@media`]: {
     [`screen and (max-width: ${BREAKPOINTS.desktop}px)`]: {

--- a/apps/web/src/components/admin/clubMember/header.css.ts
+++ b/apps/web/src/components/admin/clubMember/header.css.ts
@@ -40,7 +40,7 @@ export const excelText = style({
 export const title = style({
   fontSize: vars.fonts.title2,
   fontWeight: 600,
-  color: '#030304',
+  color: vars.colors.surface.on_surf,
 
   '@media': {
     [`screen and (max-width: ${BREAKPOINTS.desktop}px)`]: {

--- a/apps/web/src/components/admin/clubMember/memberItem.css.ts
+++ b/apps/web/src/components/admin/clubMember/memberItem.css.ts
@@ -8,7 +8,7 @@ export const container = style({
   alignItems: 'center',
   padding: '10px 20px',
   borderRadius: '6px',
-  backgroundColor: '#F8F8F9',
+  backgroundColor: vars.colors.surface.default,
   flexGrow: 1,
 
   '@media': {
@@ -41,7 +41,7 @@ export const grade = style({
 export const name = style({
   fontSize: vars.fonts.body2,
   fontWeight: '600',
-  color: '#030304',
+  color: vars.colors.surface.on_surf,
 
   '@media': {
     [`screen and (max-width: ${BREAKPOINTS.desktop}px)`]: {
@@ -107,7 +107,7 @@ export const panelContainer = style({
 
 export const panelItem = style({
   padding: '8px 0',
-  color: '#292E39',
+  color: vars.colors.surface.on_surf_var,
   fontSize: vars.fonts.body2,
   fontWeight: 600,
   cursor: 'pointer',

--- a/apps/web/src/components/admin/clubMember/rightSide.css.ts
+++ b/apps/web/src/components/admin/clubMember/rightSide.css.ts
@@ -7,7 +7,7 @@ export const sidebarTop = createVar();
 export const container = style({
   position: 'absolute',
   width: '330px',
-  backgroundColor: 'white',
+  backgroundColor: vars.colors.white,
   padding: '22px 26px',
   borderRadius: '8px',
   display: 'flex',
@@ -52,7 +52,7 @@ export const GradeText = style({
 
 export const NumberText = style({
   fontSize: vars.fonts.body1,
-  color: '#030304',
+  color: vars.colors.surface.on_surf,
   fontWeight: 500,
 
   '@media': {
@@ -99,7 +99,7 @@ export const Bar = style({
 export const divider = style({
   display: 'none',
   height: '1px',
-  backgroundColor: '#EEEEF0',
+  backgroundColor: vars.colors.surface.cont_1,
 
   [`@media`]: {
     [`screen and (max-width: ${BREAKPOINTS.desktop}px)`]: {

--- a/apps/web/src/components/admin/message/form.css.ts
+++ b/apps/web/src/components/admin/message/form.css.ts
@@ -27,7 +27,7 @@ export const messageContainer = style({
   flexDirection: 'column',
   gap: '14px',
   padding: '26px 24px',
-  backgroundColor: 'white',
+  backgroundColor: vars.colors.white,
   borderRadius: '8px',
 
   [`@media`]: {
@@ -40,7 +40,7 @@ export const messageContainer = style({
 export const sectionTitle = style({
   fontSize: vars.fonts.title4,
   fontWeight: 600,
-  color: '#030304',
+  color: vars.colors.surface.on_surf,
 
   [`@media`]: {
     [`screen and (max-width: ${BREAKPOINTS.desktop}px)`]: {
@@ -54,7 +54,7 @@ export const mainContainer = style({
   flexDirection: 'column',
   gap: '12px',
   padding: '18px 20px',
-  backgroundColor: '#F8F8F9',
+  backgroundColor: vars.colors.surface.default,
   borderRadius: '4px',
 
   [`@media`]: {

--- a/apps/web/src/components/admin/message/header.css.ts
+++ b/apps/web/src/components/admin/message/header.css.ts
@@ -20,7 +20,7 @@ export const container = style({
 export const titleText = style({
   fontSize: vars.fonts.title2,
   fontWeight: '600',
-  color: '#030304',
+  color: vars.colors.surface.on_surf,
 
   [`@media`]: {
     [`screen and (max-width: ${BREAKPOINTS.desktop}px)`]: {

--- a/apps/web/src/components/apply/form.css.ts
+++ b/apps/web/src/components/apply/form.css.ts
@@ -77,7 +77,7 @@ export const BoxFlex = style({
   display: 'flex',
   flexDirection: 'column',
   gap: '16px',
-  backgroundColor: 'white',
+  backgroundColor: vars.colors.white,
   padding: '22px 24px',
   borderRadius: '8px',
 });
@@ -85,7 +85,7 @@ export const BoxFlex = style({
 export const BoxTitle = style({
   fontSize: vars.fonts.title4,
   fontWeight: '700',
-  color: '#030304',
+  color: vars.colors.surface.on_surf,
 });
 
 export const BoxContentContainer = style({
@@ -96,7 +96,7 @@ export const BoxContentContainer = style({
 
 export const contentText = style({
   fontSize: vars.fonts.body2,
-  color: '#030304',
+  color: vars.colors.surface.on_surf,
 
   whiteSpace: 'nowrap',
   overflow: 'hidden',
@@ -122,7 +122,7 @@ export const contentContainer = style({
   flexDirection: 'column',
   gap: '18px',
   borderRadius: '8px',
-  background: 'white',
+  background: vars.colors.white,
   marginBottom: '200px',
   flexGrow: 1,
   flexShrink: 1,
@@ -187,7 +187,7 @@ export const FormSubTitle = style({
 export const FormBasicContainer = style({
   padding: '22px',
   borderRadius: '6px',
-  background: '#F8F8F9',
+  background: vars.colors.surface.default,
   display: 'flex',
   flexDirection: 'column',
   gap: '40px',
@@ -195,7 +195,7 @@ export const FormBasicContainer = style({
   '@media': {
     [`screen and (max-width: ${BREAKPOINTS.desktop}px)`]: {
       padding: '16px 14px',
-      backgroundColor: 'white',
+      backgroundColor: vars.colors.white,
       gap: '20px',
     },
   },
@@ -224,7 +224,7 @@ export const FormContentContainer = style({
 export const FormContentTitle = style({
   fontSize: vars.fonts.body1,
   fontWeight: '600',
-  color: '#030304',
+  color: vars.colors.surface.on_surf,
 
   '@media': {
     [`screen and (max-width: ${BREAKPOINTS.desktop}px)`]: {
@@ -234,7 +234,7 @@ export const FormContentTitle = style({
 });
 
 export const FormContentTitleEssential = style({
-  color: '#254FDB',
+  color: vars.colors.primary.default,
 });
 
 export const FormContentSubTitle = style({
@@ -254,7 +254,7 @@ export const FormContentSubTitle = style({
 export const FormInput = style({
   padding: '12px 16px',
   borderRadius: '6px',
-  background: 'white',
+  background: vars.colors.white,
   fontSize: vars.fonts.body2,
   lineHeight: '150%',
 
@@ -266,7 +266,7 @@ export const FormInput = style({
 
   '@media': {
     [`screen and (max-width: ${BREAKPOINTS.desktop}px)`]: {
-      backgroundColor: '#F8F8F9',
+      backgroundColor: vars.colors.surface.default,
       padding: '10px 12px',
       fontSize: vars.fonts.m_body1,
       flexShrink: '1',
@@ -288,7 +288,7 @@ export const LabelContainer = style({
 export const RadioText = style({
   fontSize: vars.fonts.body2,
   fontWeight: '500',
-  color: '#272E3B',
+  color: vars.colors.charcoal,
 
   '@media': {
     [`screen and (max-width: ${BREAKPOINTS.desktop}px)`]: {
@@ -319,11 +319,11 @@ export const questionContainer = style({
   gap: '16px',
   borderRadius: '6px',
   padding: '22px',
-  background: '#F8F8F9',
+  background: vars.colors.surface.default,
 
   '@media': {
     [`screen and (max-width: ${BREAKPOINTS.desktop}px)`]: {
-      backgroundColor: 'white',
+      backgroundColor: vars.colors.white,
       padding: '16px 14px',
       gap: '12px',
     },
@@ -345,11 +345,11 @@ export const questionHeader = style({
 export const questionTitle = style({
   fontSize: vars.fonts.title4,
   fontWeight: '600',
-  color: '#030304',
+  color: vars.colors.surface.on_surf,
 });
 
 export const essential = style({
-  color: '#254FDB',
+  color: vars.colors.primary.default,
   fontSize: vars.fonts.title4,
   fontWeight: '600',
 });
@@ -376,7 +376,7 @@ export const checkboxItem = style({
 export const checkboxLabel = style({
   fontSize: vars.fonts.body2,
   fontWeight: '500',
-  color: '#272E3B',
+  color: vars.colors.charcoal,
 
   '@media': {
     [`screen and (max-width: ${BREAKPOINTS.desktop}px)`]: {
@@ -401,7 +401,7 @@ export const radioItem = style({
 export const radioLabel = style({
   fontSize: vars.fonts.body2,
   fontWeight: '500',
-  color: '#272E3B',
+  color: vars.colors.charcoal,
 
   '@media': {
     [`screen and (max-width: ${BREAKPOINTS.desktop}px)`]: {
@@ -413,7 +413,7 @@ export const radioLabel = style({
 export const shortAnswerInput = style({
   padding: '12px 16px',
   borderRadius: '6px',
-  background: 'white',
+  background: vars.colors.white,
   fontSize: vars.fonts.body2,
   lineHeight: '150%',
 
@@ -425,7 +425,7 @@ export const shortAnswerInput = style({
 
   '@media': {
     [`screen and (max-width: ${BREAKPOINTS.desktop}px)`]: {
-      backgroundColor: '#F8F8F9',
+      backgroundColor: vars.colors.surface.default,
       padding: '10px 12px',
       fontSize: vars.fonts.m_body2,
     },
@@ -435,7 +435,7 @@ export const shortAnswerInput = style({
 export const longAnswerTextarea = style({
   padding: '12px 16px',
   borderRadius: '6px',
-  background: 'white',
+  background: vars.colors.white,
   fontSize: vars.fonts.body2,
   lineHeight: '150%',
   resize: 'vertical',
@@ -449,7 +449,7 @@ export const longAnswerTextarea = style({
 
   '@media': {
     [`screen and (max-width: ${BREAKPOINTS.desktop}px)`]: {
-      backgroundColor: '#F8F8F9',
+      backgroundColor: vars.colors.surface.default,
       padding: '10px 12px',
       fontSize: vars.fonts.m_body2,
     },
@@ -459,14 +459,14 @@ export const longAnswerTextarea = style({
 export const fileInput = style({
   padding: '12px 16px',
   borderRadius: '6px',
-  background: 'white',
+  background: vars.colors.white,
   fontSize: vars.fonts.body2,
   lineHeight: '150%',
   border: '1px solid #E5E7EB',
 
   '@media': {
     [`screen and (max-width: ${BREAKPOINTS.desktop}px)`]: {
-      backgroundColor: '#F8F8F9',
+      backgroundColor: vars.colors.surface.default,
       padding: '10px 12px',
       fontSize: vars.fonts.m_body1,
     },

--- a/apps/web/src/components/clubInfo/clubIntro.css.ts
+++ b/apps/web/src/components/clubInfo/clubIntro.css.ts
@@ -48,7 +48,7 @@ export const headerItem2 = style({
   // fontWeight: 700,
   fontSize: vars.fonts.body2,
   color: '#55637D !important',
-  backgroundColor: '#EEEEF0 !important',
+  backgroundColor: `${vars.colors.surface.cont_1} !important`,
 
   '@media': {
     [`screen and (max-width: ${BREAKPOINTS.desktop}px)`]: {
@@ -61,7 +61,7 @@ export const headerItem2 = style({
 export const contentContainer = style({
   width: '100%',
   padding: '26px 28px',
-  backgroundColor: 'white',
+  backgroundColor: vars.colors.white,
   minHeight: '300px',
   borderRadius: '0 0 8px 8px',
 });

--- a/apps/web/src/components/clubInfo/clubProfile.css.ts
+++ b/apps/web/src/components/clubInfo/clubProfile.css.ts
@@ -28,7 +28,7 @@ export const imageStyle = style({
 
 export const RightFlex = style({
   flex: '1 0 0',
-  backgroundColor: 'white',
+  backgroundColor: vars.colors.white,
   borderRadius: '8px',
   padding: '22px',
   minWidth: 0,

--- a/apps/web/src/components/clubInfo/rightSide.css.ts
+++ b/apps/web/src/components/clubInfo/rightSide.css.ts
@@ -31,7 +31,7 @@ export const contentFlex = style({
   display: 'flex',
   flexDirection: 'column',
   gap: '10px',
-  backgroundColor: 'white',
+  backgroundColor: vars.colors.white,
   padding: '24px 26px',
   borderRadius: '8px',
   marginBottom: '20px',

--- a/apps/web/src/components/favorites/favorites.css.ts
+++ b/apps/web/src/components/favorites/favorites.css.ts
@@ -9,7 +9,7 @@ export const lottieContainer = style({
 
 export const emptyText = style({
   width: '100%',
-  backgroundColor: 'white',
+  backgroundColor: vars.colors.white,
   height: '700px',
   display: 'flex',
   justifyContent: 'center',
@@ -19,7 +19,7 @@ export const emptyText = style({
   borderRadius: '8px',
   fontSize: vars.fonts.title3,
   fontWeight: 500,
-  color: '#E0E1E3',
+  color: vars.colors.surface.cont_3,
   marginTop: '20px',
   marginBottom: '180px',
 

--- a/apps/web/src/components/favorites/index.css.ts
+++ b/apps/web/src/components/favorites/index.css.ts
@@ -47,7 +47,7 @@ export const HeaderContainer = recipe({
 
 export const SortFlex = style({
   display: 'flex',
-  backgroundColor: 'white',
+  backgroundColor: vars.colors.white,
   borderRadius: '8px',
   padding: '4px',
 

--- a/apps/web/src/components/login/login.css.ts
+++ b/apps/web/src/components/login/login.css.ts
@@ -166,7 +166,7 @@ export const adminLoginButton = style({
 export const userInput = style({
   padding: '12px 16px',
   borderRadius: '6px',
-  backgroundColor: '#F8F8F9',
+  backgroundColor: vars.colors.surface.default,
   fontSize: '14px',
   selectors: {
     '&::placeholder': {

--- a/apps/web/src/components/password/index.css.ts
+++ b/apps/web/src/components/password/index.css.ts
@@ -48,7 +48,7 @@ export const Title = style({
 export const BoxContainer = recipe({
   base: {
     padding: '32px',
-    backgroundColor: 'white',
+    backgroundColor: vars.colors.white,
     display: 'flex',
     borderRadius: '8px',
 
@@ -149,7 +149,7 @@ export const InputButtonFlex = style({
 export const Input = style({
   flex: '1 1 0',
   padding: '12px 16px',
-  backgroundColor: '#F8F8F9 !important',
+  backgroundColor: `${vars.colors.surface.default} !important`,
   lineHeight: '1.5',
   minWidth: '0',
   selectors: {

--- a/apps/web/src/components/signup/signup.css.ts
+++ b/apps/web/src/components/signup/signup.css.ts
@@ -47,7 +47,7 @@ export const TitleText = style({
 
 export const LabelBoxContainer = style({
   borderRadius: '6px',
-  backgroundColor: 'white',
+  backgroundColor: vars.colors.white,
   padding: '32px',
   display: 'flex',
   // gap: '112px',
@@ -138,7 +138,7 @@ export const EmailText = style({
 });
 
 export const Input = style({
-  backgroundColor: '#F8F8F9',
+  backgroundColor: vars.colors.surface.default,
   borderRadius: '6px',
   padding: '12px 16px',
   fontSize: '16px',
@@ -148,7 +148,7 @@ export const Input = style({
 
   selectors: {
     '&::placeholder': {
-      color: '#E0E1E3',
+      color: vars.colors.surface.cont_3,
     },
     '&:disabled': {
       opacity: 0.5,
@@ -191,9 +191,9 @@ export const FlexPolicy = style({
 
 export const PolicyBox = style({
   padding: '20px 24px',
-  backgroundColor: '#F8F8F9',
+  backgroundColor: vars.colors.surface.default,
   borderRadius: '6px',
-  color: '#272E3B',
+  color: vars.colors.charcoal,
   fontSize: vars.fonts.body3,
   whiteSpace: 'pre-line',
   height: '220px',
@@ -208,7 +208,7 @@ export const FlexAgree = style({
 });
 
 export const AgreeText = style({
-  color: '#272E3B',
+  color: vars.colors.charcoal,
   fontSize: vars.fonts.body2,
 });
 

--- a/apps/web/src/components/signup/signupComplete.css.ts
+++ b/apps/web/src/components/signup/signupComplete.css.ts
@@ -8,7 +8,7 @@ export const CompleteBox = style({
   left: '50%',
   transform: 'translate(-50%, -50%)',
 
-  backgroundColor: 'white',
+  backgroundColor: vars.colors.white,
   borderRadius: '12px',
   padding: '48px',
   width: '100%',
@@ -40,7 +40,7 @@ export const CompleteTitle = style({
 
 export const CompleteText = style({
   fontSize: vars.fonts.body2,
-  color: '#272E3B',
+  color: vars.colors.charcoal,
   lineHeight: 1.6,
   marginBottom: '30px',
 


### PR DESCRIPTION
### 작업 내용
codemod 기반으로 디자인 토큰을 자동 변경 했어요.

- 프로젝트 전체에 산재한 하드코딩 hex 색상값(`#fff`, `#030304`, `#272E3B`, `#F8F8F9` 등)을 디자인 시스템 토큰(`vars.colors.*`)으로 일괄 교체

<img width="432" height="179" alt="image" src="https://github.com/user-attachments/assets/f3ddc876-4916-41be-b3ed-2826bd50d81f" />

- 주요 치환 매핑: `'white'`/`'#fff'` → `vars.colors.white`, `'#F8F8F9'` → `vars.colors.surface.default`, `'#030304'` → `vars.colors.surface.on_surf`, `'#272E3B'` → `vars.colors.charcoal`, `'#BE3439'` → `vars.colors.error.primary`



### 연관 이슈

close #304
