### PR TITLE
검색어 이동과 모바일 구글 로그인 버튼 복구 처리(issue #331)

### DIFF
--- a/apps/web/src/common/components/header/clientHeader/desktop.tsx
+++ b/apps/web/src/common/components/header/clientHeader/desktop.tsx
@@ -17,7 +17,7 @@ interface DesktopProps<T> {
   isComboBoxOpen: boolean;
   setIsComboBoxOpen: (isOpen: boolean) => void;
   handleSearchChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  handleNavigate: () => void;
+  handleNavigate: (keyword?: string) => void;
   handleKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   searchList: T[];
   userName: string | null;

--- a/apps/web/src/common/components/header/clientHeader/mobile.tsx
+++ b/apps/web/src/common/components/header/clientHeader/mobile.tsx
@@ -18,7 +18,7 @@ interface MobileProps<T> {
   isComboBoxOpen: boolean;
   setIsComboBoxOpen: (isOpen: boolean) => void;
   handleSearchChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  handleNavigate: () => void;
+  handleNavigate: (keyword?: string) => void;
   handleKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   searchList: T[];
   userName: string | null;
@@ -51,8 +51,8 @@ function Mobile<T extends { id: string; name: string; clubType: string }>({
     setIsComboBoxOpen(false);
   };
 
-  const handleMobileNavigate = () => {
-    handleNavigate();
+  const handleMobileNavigate = (keyword?: string) => {
+    handleNavigate(keyword);
     closeSearchBar();
   };
 

--- a/apps/web/src/common/components/inputCombobox/index.tsx
+++ b/apps/web/src/common/components/inputCombobox/index.tsx
@@ -5,7 +5,7 @@ import * as S from './inputCombobox.css';
 import SearchBar from '@/common/ui/searchBar';
 import { useOutsideClick } from '@/hooks/useOutsideClick';
 
-interface InputComboboxProps<T> extends InputHTMLAttributes<HTMLInputElement> {
+interface InputComboboxProps<T> extends Omit<InputHTMLAttributes<HTMLInputElement>, 'onClick'> {
   variant?: 'primary';
   className?: string;
   iconStyle?: string;
@@ -14,7 +14,7 @@ interface InputComboboxProps<T> extends InputHTMLAttributes<HTMLInputElement> {
   isComboBoxOpen?: boolean;
   setIsComboBoxOpen: (isOpen: boolean) => void;
   setIsSearchBarOpen?: (isOpen: boolean) => void;
-  onClick?: () => void;
+  onClick?: (value: string) => void;
 }
 
 function InputCombobox<T extends { id: string; name: string; clubType: string }>({

--- a/apps/web/src/common/ui/searchBar/index.tsx
+++ b/apps/web/src/common/ui/searchBar/index.tsx
@@ -1,13 +1,13 @@
-import React, { InputHTMLAttributes } from 'react';
+import React, { InputHTMLAttributes, useRef } from 'react';
 import Input from '../input';
 import * as S from './searchBar.css';
 import Image from 'next/image';
 
-interface SearchBarProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'style'> {
+interface SearchBarProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'style' | 'onClick'> {
   icon: string;
   variant?: 'primary' | 'secondary' | 'tertiary';
   iconStyle?: string;
-  onClick?: () => void;
+  onClick?: (value: string) => void;
 }
 
 function SearchBar({
@@ -19,12 +19,13 @@ function SearchBar({
   ...props
 }: SearchBarProps) {
   const iconContainerStyle = `${S.iconContainerBase} ${iconStyle}`;
+  const inputRef = useRef<HTMLInputElement>(null);
 
   return (
     <div className={S.searchBarContainer}>
-      <Input {...props} className={className} variant={variant} />
+      <Input {...props} ref={inputRef} className={className} variant={variant} />
       <span className={iconContainerStyle}>
-        <Image src={icon} alt="검색" onClick={onClick} />
+        <Image src={icon} alt="검색" onClick={() => onClick?.(inputRef.current?.value ?? '')} />
       </span>
     </div>
   );

--- a/apps/web/src/components/login/googleLogin/index.tsx
+++ b/apps/web/src/components/login/googleLogin/index.tsx
@@ -31,6 +31,13 @@ export default function GoogleLoginButton({ onCredential }: GoogleLoginButtonPro
     onCredentialRef.current = onCredential;
   }, [onCredential]);
 
+  const clearRecoveryTimer = useCallback(() => {
+    if (!recoveryTimerRef.current) return;
+
+    window.clearTimeout(recoveryTimerRef.current);
+    recoveryTimerRef.current = undefined;
+  }, []);
+
   const queueButtonRender = useCallback((delay = 100) => {
     if (resetTimerRef.current) {
       window.clearTimeout(resetTimerRef.current);
@@ -66,9 +73,8 @@ export default function GoogleLoginButton({ onCredential }: GoogleLoginButtonPro
     const resetButton = () => {
       if (document.visibilityState !== 'visible') return;
 
-      if (authAttemptStartedRef.current && recoveryTimerRef.current) {
-        window.clearTimeout(recoveryTimerRef.current);
-        recoveryTimerRef.current = undefined;
+      if (authAttemptStartedRef.current) {
+        clearRecoveryTimer();
       }
 
       authAttemptStartedRef.current = false;
@@ -92,7 +98,7 @@ export default function GoogleLoginButton({ onCredential }: GoogleLoginButtonPro
       window.removeEventListener('pageshow', resetButton);
       document.removeEventListener('visibilitychange', resetButton);
     };
-  }, [queueButtonRender]);
+  }, [clearRecoveryTimer, queueButtonRender]);
 
   // 화면 회전·리사이즈로 카드 폭이 바뀌면 버튼도 다시 그려야 한다.
   const [slotWidth, setSlotWidth] = useState(0);
@@ -117,12 +123,13 @@ export default function GoogleLoginButton({ onCredential }: GoogleLoginButtonPro
       client_id: clientId,
       callback: ({ credential }) => {
         authAttemptStartedRef.current = false;
+        clearRecoveryTimer();
         onCredentialRef.current(credential);
       },
       auto_select: false,
       use_fedcm_for_button: false,
     });
-  }, [isScriptReady, clientId]);
+  }, [isScriptReady, clientId, clearRecoveryTimer]);
 
   useEffect(() => {
     const buttonSlot = buttonSlotRef.current;

--- a/apps/web/src/components/login/googleLogin/index.tsx
+++ b/apps/web/src/components/login/googleLogin/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Script from 'next/script';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import * as S from './googleLogin.css';
 
 const GIS_SCRIPT_SRC = 'https://accounts.google.com/gsi/client';
@@ -19,6 +19,9 @@ interface GoogleLoginButtonProps {
 export default function GoogleLoginButton({ onCredential }: GoogleLoginButtonProps) {
   const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
   const buttonSlotRef = useRef<HTMLDivElement>(null);
+  const authAttemptStartedRef = useRef(false);
+  const resetTimerRef = useRef<number | undefined>(undefined);
+  const recoveryTimerRef = useRef<number | undefined>(undefined);
   const [isScriptReady, setIsScriptReady] = useState(false);
   const [renderVersion, setRenderVersion] = useState(0);
 
@@ -28,35 +31,68 @@ export default function GoogleLoginButton({ onCredential }: GoogleLoginButtonPro
     onCredentialRef.current = onCredential;
   }, [onCredential]);
 
-  // 사용자가 구글 인증 창에서 취소/닫기를 누르면 GIS 버튼 iframe이 포커스를 잡은 채
-  // 다시 클릭되지 않는 경우가 있어, 페이지가 돌아왔을 때 버튼을 새로 그린다.
-  useEffect(() => {
-    let resetTimer: number | undefined;
+  const queueButtonRender = useCallback((delay = 100) => {
+    if (resetTimerRef.current) {
+      window.clearTimeout(resetTimerRef.current);
+    }
 
+    resetTimerRef.current = window.setTimeout(() => {
+      setRenderVersion((version) => version + 1);
+    }, delay);
+  }, []);
+
+  const handleAuthAttemptStart = useCallback(() => {
+    authAttemptStartedRef.current = true;
+
+    if (recoveryTimerRef.current) {
+      window.clearTimeout(recoveryTimerRef.current);
+    }
+
+    const isMobileLike =
+      window.matchMedia(`(max-width: 1023px)`).matches || window.navigator.maxTouchPoints > 0;
+
+    if (!isMobileLike) return;
+
+    recoveryTimerRef.current = window.setTimeout(() => {
+      if (document.visibilityState === 'visible') {
+        queueButtonRender(0);
+      }
+    }, 2500);
+  }, [queueButtonRender]);
+
+  // 사용자가 구글 인증 화면에서 취소/닫기를 누르면 GIS 버튼 iframe이 멈춘 상태로
+  // 남는 경우가 있어, 페이지가 다시 보일 때 버튼을 새로 그린다.
+  useEffect(() => {
     const resetButton = () => {
       if (document.visibilityState !== 'visible') return;
 
-      if (resetTimer) {
-        window.clearTimeout(resetTimer);
+      if (authAttemptStartedRef.current && recoveryTimerRef.current) {
+        window.clearTimeout(recoveryTimerRef.current);
+        recoveryTimerRef.current = undefined;
       }
 
-      resetTimer = window.setTimeout(() => {
-        setRenderVersion((version) => version + 1);
-      }, 100);
+      authAttemptStartedRef.current = false;
+      queueButtonRender();
     };
 
     window.addEventListener('focus', resetButton);
+    window.addEventListener('pageshow', resetButton);
     document.addEventListener('visibilitychange', resetButton);
 
     return () => {
-      if (resetTimer) {
-        window.clearTimeout(resetTimer);
+      if (resetTimerRef.current) {
+        window.clearTimeout(resetTimerRef.current);
+      }
+
+      if (recoveryTimerRef.current) {
+        window.clearTimeout(recoveryTimerRef.current);
       }
 
       window.removeEventListener('focus', resetButton);
+      window.removeEventListener('pageshow', resetButton);
       document.removeEventListener('visibilitychange', resetButton);
     };
-  }, []);
+  }, [queueButtonRender]);
 
   // 화면 회전·리사이즈로 카드 폭이 바뀌면 버튼도 다시 그려야 한다.
   const [slotWidth, setSlotWidth] = useState(0);
@@ -79,7 +115,10 @@ export default function GoogleLoginButton({ onCredential }: GoogleLoginButtonPro
 
     window.google.accounts.id.initialize({
       client_id: clientId,
-      callback: ({ credential }) => onCredentialRef.current(credential),
+      callback: ({ credential }) => {
+        authAttemptStartedRef.current = false;
+        onCredentialRef.current(credential);
+      },
       auto_select: false,
       use_fedcm_for_button: false,
     });
@@ -103,8 +142,9 @@ export default function GoogleLoginButton({ onCredential }: GoogleLoginButtonPro
       logo_alignment: 'center',
       locale: 'ko',
       width: Math.min(MAX_BUTTON_WIDTH, slotWidth),
+      click_listener: handleAuthAttemptStart,
     });
-  }, [isScriptReady, clientId, slotWidth, renderVersion]);
+  }, [isScriptReady, clientId, slotWidth, renderVersion, handleAuthAttemptStart]);
 
   if (!clientId) {
     if (process.env.NODE_ENV !== 'production') {

--- a/apps/web/src/hooks/useComboBox.ts
+++ b/apps/web/src/hooks/useComboBox.ts
@@ -17,8 +17,9 @@ export const useCombobox = () => {
     setIsComboBoxOpen(!!debouncedSearch);
   }, [debouncedSearch]);
 
-  const handleNavigate = (keyword = searchdata) => {
-    router.push(ROUTES.SEARCH(keyword.trim()));
+  const handleNavigate = (keyword?: string) => {
+    const searchKeyword = typeof keyword === 'string' ? keyword : searchdata;
+    router.push(ROUTES.SEARCH(searchKeyword.trim()));
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/apps/web/src/types/google.d.ts
+++ b/apps/web/src/types/google.d.ts
@@ -25,6 +25,7 @@ interface GoogleButtonConfiguration {
   logo_alignment?: 'left' | 'center';
   width?: number;
   locale?: string;
+  click_listener?: () => void;
 }
 
 interface GoogleAccountsId {


### PR DESCRIPTION
### 작업 내용

- [x] 검색바 돋보기 아이콘 클릭 시에도 현재 입력값을 검색어로 전달해 이동하도록 수정 (기존에는 `handleNavigate`가 인자 없이 호출되어 디바운스 반영 전 최신 입력값이 검색에 반영되지 않는 문제가 있었음)
- [x] 모바일 헤더 검색 아이콘 클릭 시에도 동일하게 키워드를 전달하고, 검색바를 닫도록 처리
- [x] 모바일 환경에서 구글 로그인 인증 창을 취소/닫았을 때 GIS 버튼 iframe이 멈춘 채로 남아 재클릭이 안 되던 문제 개선: 버튼의 `click_listener`로 인증 시도 시작 시점을 추적하고, 일정 시간 응답이 없으면 복구 타이머로 버튼을 다시 그리도록 처리
- [x] `pageshow` 이벤트 리스너를 추가해 bfcache로 페이지가 복귀하는 경우에도 버튼 상태가 복구되도록 보강
- 모바일 여부 판단을 `matchMedia(max-width: 1023px)`와 `navigator.maxTouchPoints`로 하고 있어, 터치 지원 데스크탑 등 일부 기기에서 복구 타이머가 불필요하게 동작할 가능성이 있음
- 리뷰어는 `googleLogin/index.tsx`의 `resetTimerRef` / `recoveryTimerRef` 두 타이머의 설정·해제 순서와 클린업 로직을 중점적으로 봐주시면 좋을 것 같습니다
- 복구 타이머 지연값(2500ms)이 실제 사용자 흐름에 적절한지 논의하고 싶습니다

### 연관 이슈

close #331


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 검색창의 아이콘을 누르면 현재 입력한 검색어로 바로 검색 결과로 이동합니다.
  - 검색어 앞뒤의 불필요한 공백이 자동으로 정리됩니다.

- **버그 수정**
  - 모바일 환경에서 Google 로그인 후 화면 복귀 시 로그인 버튼이 표시되지 않을 수 있는 문제를 개선했습니다.
  - 인증 시도 후 버튼이 정상적으로 복구되도록 안정성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->