### PR TITLE
Safari 구글 로그인 버튼 복구 및 인증 화면 정리(issue #337)

### DIFF
--- a/apps/web/src/app/(default-header)/(without-footer)/signup/page.tsx
+++ b/apps/web/src/app/(default-header)/(without-footer)/signup/page.tsx
@@ -268,7 +268,7 @@ export default function Page() {
         isOpen={isOpen}
         onClose={handleModalClose}
         onConfirm={handleModalClose}
-        confirmHref="https://cloud.smu.ac.kr/t/smu.ac.kr"
+        confirmHref="https://cloud.smu.ac.kr/auth/sso/login"
         title="인증코드 발급"
         message={
           <>

--- a/apps/web/src/components/admin/login/index.tsx
+++ b/apps/web/src/components/admin/login/index.tsx
@@ -59,10 +59,10 @@ function LoginPage() {
           {...register('password')}
         />
         <div className={S.AdminAuthContainer}>
-          <div className={S.AdminSignUp} title="아이디 찾기는 관리자에게 문의바랍니다" onClick={() => alert('아이디 찾기는 관리자에게 문의바랍니다')}>
+          {/* <div className={S.AdminSignUp} title="아이디 찾기는 관리자에게 문의바랍니다" onClick={() => alert('아이디 찾기는 관리자에게 문의바랍니다')}>
             아이디 찾기
-          </div>
-          <div className={S.AdminSignUp}>|</div>
+          </div> */}
+          {/* <div className={S.AdminSignUp}>|</div> */}
           <Link href={ROUTES.ADMIN_PASSWORD} className={S.AdminSignUp}>
             비밀번호 재설정
           </Link>

--- a/apps/web/src/components/admin/signup/page.tsx
+++ b/apps/web/src/components/admin/signup/page.tsx
@@ -66,8 +66,8 @@ function SignupPage() {
           errorMessage={errors.password?.message}
           {...register('password')}
         />
-
-        <label className={S.Label({ isFirst: false })}>이메일</label>
+        {/* v2를 위한 임시 주석 */}
+        {/* <label className={S.Label({ isFirst: false })}>이메일</label>
         <Input
           type="email"
           variant="secondary"
@@ -76,7 +76,7 @@ function SignupPage() {
           isError={!!errors.email}
           errorMessage={errors.email?.message}
           {...register('email')}
-        />
+        /> */}
 
         <label className={S.Label({ isFirst: false })}>동아리 이름</label>
         <Input

--- a/apps/web/src/components/login/googleLogin/index.tsx
+++ b/apps/web/src/components/login/googleLogin/index.tsx
@@ -27,6 +27,7 @@ export default function GoogleLoginButton({ onCredential }: GoogleLoginButtonPro
   const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
   const buttonSlotRef = useRef<HTMLDivElement>(null);
   const authAttemptStartedRef = useRef(false);
+  const canRecoverAuthButtonRef = useRef(false);
   const resetTimerRef = useRef<number | undefined>(undefined);
   const recoveryTimerRef = useRef<number | undefined>(undefined);
   const [isScriptReady, setIsScriptReady] = useState(false);
@@ -57,6 +58,7 @@ export default function GoogleLoginButton({ onCredential }: GoogleLoginButtonPro
 
   const handleAuthAttemptStart = useCallback(() => {
     authAttemptStartedRef.current = true;
+    canRecoverAuthButtonRef.current = false;
     clearRecoveryTimer();
 
     const isMobileLike =
@@ -65,21 +67,18 @@ export default function GoogleLoginButton({ onCredential }: GoogleLoginButtonPro
     if (!isMobileLike) return;
 
     recoveryTimerRef.current = window.setTimeout(() => {
-      if (document.visibilityState === 'visible') {
-        queueButtonRender(0);
-      }
+      canRecoverAuthButtonRef.current = true;
     }, 2500);
-  }, [clearRecoveryTimer, queueButtonRender]);
+  }, [clearRecoveryTimer]);
 
   useEffect(() => {
     const resetButton = () => {
       if (document.visibilityState !== 'visible') return;
+      if (!authAttemptStartedRef.current || !canRecoverAuthButtonRef.current) return;
 
-      if (authAttemptStartedRef.current) {
-        clearRecoveryTimer();
-      }
-
+      clearRecoveryTimer();
       authAttemptStartedRef.current = false;
+      canRecoverAuthButtonRef.current = false;
       queueButtonRender();
     };
 
@@ -123,6 +122,7 @@ export default function GoogleLoginButton({ onCredential }: GoogleLoginButtonPro
       client_id: clientId,
       callback: ({ credential }) => {
         authAttemptStartedRef.current = false;
+        canRecoverAuthButtonRef.current = false;
         clearRecoveryTimer();
         onCredentialRef.current(credential);
       },
@@ -130,6 +130,9 @@ export default function GoogleLoginButton({ onCredential }: GoogleLoginButtonPro
       // 타이머나 visibilitychange 추측 대신 이 콜백이 왔을 때만 버튼을 다시 그린다.
       // (그래야 2.5초 넘게 걸리는 정상 인증 도중에 iframe이 날아가는 일이 없다)
       intermediate_iframe_close_callback: () => {
+        authAttemptStartedRef.current = false;
+        canRecoverAuthButtonRef.current = false;
+        clearRecoveryTimer();
         queueButtonRender();
       },
       auto_select: false,

--- a/apps/web/src/components/login/googleLogin/index.tsx
+++ b/apps/web/src/components/login/googleLogin/index.tsx
@@ -26,7 +26,9 @@ interface GoogleLoginButtonProps {
 export default function GoogleLoginButton({ onCredential }: GoogleLoginButtonProps) {
   const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
   const buttonSlotRef = useRef<HTMLDivElement>(null);
+  const authAttemptStartedRef = useRef(false);
   const resetTimerRef = useRef<number | undefined>(undefined);
+  const recoveryTimerRef = useRef<number | undefined>(undefined);
   const [isScriptReady, setIsScriptReady] = useState(false);
   const [renderVersion, setRenderVersion] = useState(0);
 
@@ -35,6 +37,13 @@ export default function GoogleLoginButton({ onCredential }: GoogleLoginButtonPro
   useEffect(() => {
     onCredentialRef.current = onCredential;
   }, [onCredential]);
+
+  const clearRecoveryTimer = useCallback(() => {
+    if (!recoveryTimerRef.current) return;
+
+    window.clearTimeout(recoveryTimerRef.current);
+    recoveryTimerRef.current = undefined;
+  }, []);
 
   const queueButtonRender = useCallback((delay = 100) => {
     if (resetTimerRef.current) {
@@ -46,13 +55,50 @@ export default function GoogleLoginButton({ onCredential }: GoogleLoginButtonPro
     }, delay);
   }, []);
 
+  const handleAuthAttemptStart = useCallback(() => {
+    authAttemptStartedRef.current = true;
+    clearRecoveryTimer();
+
+    const isMobileLike =
+      window.matchMedia(`(max-width: 1023px)`).matches || window.navigator.maxTouchPoints > 0;
+
+    if (!isMobileLike) return;
+
+    recoveryTimerRef.current = window.setTimeout(() => {
+      if (document.visibilityState === 'visible') {
+        queueButtonRender(0);
+      }
+    }, 2500);
+  }, [clearRecoveryTimer, queueButtonRender]);
+
   useEffect(() => {
+    const resetButton = () => {
+      if (document.visibilityState !== 'visible') return;
+
+      if (authAttemptStartedRef.current) {
+        clearRecoveryTimer();
+      }
+
+      authAttemptStartedRef.current = false;
+      queueButtonRender();
+    };
+
+    window.addEventListener('focus', resetButton);
+    window.addEventListener('pageshow', resetButton);
+    document.addEventListener('visibilitychange', resetButton);
+
     return () => {
       if (resetTimerRef.current) {
         window.clearTimeout(resetTimerRef.current);
       }
+
+      clearRecoveryTimer();
+
+      window.removeEventListener('focus', resetButton);
+      window.removeEventListener('pageshow', resetButton);
+      document.removeEventListener('visibilitychange', resetButton);
     };
-  }, []);
+  }, [clearRecoveryTimer, queueButtonRender]);
 
   // 화면 회전·리사이즈로 카드 폭이 바뀌면 버튼도 다시 그려야 한다.
   const [slotWidth, setSlotWidth] = useState(0);
@@ -76,7 +122,8 @@ export default function GoogleLoginButton({ onCredential }: GoogleLoginButtonPro
     window.google.accounts.id.initialize({
       client_id: clientId,
       callback: ({ credential }) => {
-        queueButtonRender();
+        authAttemptStartedRef.current = false;
+        clearRecoveryTimer();
         onCredentialRef.current(credential);
       },
       // 사용자가 인증을 완료하지 않고 중간 iframe/시트를 닫았을 때 GIS가 보내주는 공식 신호.
@@ -108,8 +155,9 @@ export default function GoogleLoginButton({ onCredential }: GoogleLoginButtonPro
       logo_alignment: 'center',
       locale: 'ko',
       width: Math.min(MAX_BUTTON_WIDTH, Math.max(0, slotWidth - BUTTON_WIDTH_SAFETY_MARGIN)),
+      click_listener: handleAuthAttemptStart,
     });
-  }, [isScriptReady, clientId, slotWidth, renderVersion]);
+  }, [isScriptReady, clientId, slotWidth, renderVersion, handleAuthAttemptStart]);
 
   if (!clientId) {
     if (process.env.NODE_ENV !== 'production') {

--- a/apps/web/src/hooks/useAdminMutation.ts
+++ b/apps/web/src/hooks/useAdminMutation.ts
@@ -24,7 +24,7 @@ export const useLoginMutation = () => {
     onError: (error) => {
       const customError = error as CustomHttpError;
       if (customError.status !== 401) {
-        alert('로그인 중 오류가 발생했습니다.');
+        alert('아이디 혹은 비밀번호를 확인해주세요');
       }
     },
   });


### PR DESCRIPTION
### 작업 내용

- Safari(특히 모바일)에서 구글 로그인 버튼 클릭 후 인증 시트를 닫으면 버튼이 다시 반응하지 않던 문제를 해결하기 위해, 인증 시도 상태(`authAttemptStartedRef`)와 모바일 환경 전용 복구 타이머(`recoveryTimerRef`)를 추가하고 `focus`/`pageshow`/`visibilitychange` 이벤트에서 버튼을 재렌더링하도록 구현. 관리자 로그인/회원가입 화면은 v2 개편 전까지 사용하지 않는 UI(아이디 찾기 링크, 이메일 입력 필드)를 임시로 주석 처리. 회원가입 인증코드 발급 안내 링크를 SSO 로그인 경로(`/auth/sso/login`)로 수정하고, 관리자 로그인 실패 메시지를 좀 더 구체적으로 변경.
- 관리자 화면의 주석 처리 코드는 삭제가 아닌 주석 처리라 v2 작업 전까지 코드베이스에 죽은 코드로 남아있음.
- `googleLogin/index.tsx`의 타이머/이벤트 리스너 cleanup 로직이 정상적으로 해제되는지 집중 검토 부탁드립니다.
- 복구 타이머 지연 시간(2.5초)이 적절한지, 데스크톱 환경에는 복구 로직을 적용하지 않은 판단이 맞는지 논의하고 싶습니다.

### 📸 스크린샷

| As-is | To-be |
| ----- | ----- |
|       |       |

### 연관 이슈

close #337


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 모바일 환경에서 Google 로그인 후 화면이 정상적으로 복귀되지 않는 상황을 자동으로 감지하고 복구합니다.

- **버그 수정**
  - 인증코드 발급 완료 안내의 확인 링크를 올바른 로그인 페이지로 변경했습니다.
  - 로그인 실패 시 아이디와 비밀번호를 확인하도록 안내 문구를 개선했습니다.

- **변경 사항**
  - 관리자 로그인 화면의 ‘아이디 찾기’ 링크를 비활성화했습니다.
  - 관리자 회원가입 화면에서 이메일 입력 항목을 숨겼습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->