### PR TITLE
GA 이벤트 추적 및 회원가입·지원폼 UX 개선(issue #326)

### DIFF
--- a/apps/web/src/app/(client-header)/(with-footer)/club/[clubId]/apply/page.tsx
+++ b/apps/web/src/app/(client-header)/(with-footer)/club/[clubId]/apply/page.tsx
@@ -1,10 +1,8 @@
 'use client';
 
-// import { useParams } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import * as S from '@/components/apply/index.css';
 import BackButton from '@/components/clubInfo/BackButton';
-// import RightSide from '@/components/apply/RightSide';
 import { useParams } from 'next/navigation';
 
 const Form = dynamic(() => import('@/components/apply/Form'), { ssr: false });
@@ -18,7 +16,6 @@ export default function Page() {
       <div className={S.container}>
         <BackButton title="지원 폼 작성" />
         <Form clubId={clubId} />
-        {/* <RightSide /> */}
       </div>
     </div>
   );

--- a/apps/web/src/app/(default-header)/(with-footer)/login/page.tsx
+++ b/apps/web/src/app/(default-header)/(with-footer)/login/page.tsx
@@ -11,18 +11,25 @@ import { postLogin } from '@/components/login/api';
 import { initializeAndSendFCMToken } from '@/fcm/fcmToken';
 import GoogleLoginButton from '@/components/login/googleLogin';
 import GoogleOnboarding from '@/components/login/googleOnboarding';
+import SignupComplete from '@/components/signup/SignupComplete';
 import { useGoogleLogin } from '@/hooks/useGoogleLogin';
 
 export default function Page() {
   const router = useRouter();
-  const { onboarding, isPending, handleCredential, submitOnboarding, cancelOnboarding } =
-    useGoogleLogin();
+  const {
+    onboarding,
+    completedSignupName,
+    isPending,
+    handleCredential,
+    submitOnboarding,
+    cancelOnboarding,
+    completeLogin,
+  } = useGoogleLogin();
 
   const {
     register,
     handleSubmit,
     formState: { errors },
-    // setError,
   } = useForm<LoginForm>({
     resolver: zodResolver(loginSchema),
     mode: 'onSubmit',
@@ -63,6 +70,10 @@ export default function Page() {
         onCancel={cancelOnboarding}
       />
     );
+  }
+
+  if (completedSignupName) {
+    return <SignupComplete userName={completedSignupName} onStart={completeLogin} />;
   }
 
   return (

--- a/apps/web/src/app/(default-header)/(without-footer)/signup/page.tsx
+++ b/apps/web/src/app/(default-header)/(without-footer)/signup/page.tsx
@@ -10,6 +10,7 @@ import { signupSchema, SignupForm } from '@/components/signup/schema';
 import SignupComplete from '@/components/signup/SignupComplete';
 import { postEmail, postCode, postSignup } from '@/components/signup/api';
 import { CustomHttpError } from '@/common/apis/apiClient';
+import { GA_EVENTS, GA_METHODS } from '@/common/constants/gaEvents';
 import { useModal } from '@/hooks/useModal';
 import ConfirmCancelModal from '@/common/components/confirmCancelModal';
 import { trackGAEvent } from '@/lib/ga';
@@ -31,7 +32,7 @@ export default function Page() {
 
   const handleSendEmail = async () => {
     const studentId = getValues('studentId');
-    trackGAEvent('email_request');
+    trackGAEvent(GA_EVENTS.EMAIL_REQUEST);
     // studentId가 9자리가 아니면 요청하지 않음
     if (studentId.length !== 9) {
       alert('학번은 9자리여야 합니다.');
@@ -42,14 +43,14 @@ export default function Page() {
       const email = `${studentId}@sangmyung.kr`;
       const response = await postEmail({ email });
       if (response.success) {
-        trackGAEvent('email_success');
+        trackGAEvent(GA_EVENTS.EMAIL_SUCCESS);
         handleModalOpen();
       } else {
-        trackGAEvent('email_fail');
+        trackGAEvent(GA_EVENTS.EMAIL_FAIL);
         alert(response.message);
       }
     } catch (error) {
-      trackGAEvent('email_error');
+      trackGAEvent(GA_EVENTS.EMAIL_ERROR);
       console.error('이메일 전송 중 오류 발생:', error);
       alert('이메일 전송 중 오류가 발생했습니다. 다시 시도해주세요.');
     }
@@ -60,26 +61,26 @@ export default function Page() {
       const studentId = getValues('studentId');
       const email = `${studentId}@sangmyung.kr`;
       const code = getValues('code');
-      trackGAEvent('verify_code_attempt', {
+      trackGAEvent(GA_EVENTS.VERIFY_CODE_ATTEMPT, {
         signup_step: 'email_verification',
         has_student_id: Boolean(studentId),
         has_code: Boolean(code),
       });
       const response = await postCode({ email, code });
       if (response.success) {
-        trackGAEvent('verify_code_success', {
+        trackGAEvent(GA_EVENTS.VERIFY_CODE_SUCCESS, {
           signup_step: 'email_verification',
         });
         alert(response.message);
         setIsVerified(true);
       } else {
-        trackGAEvent('verify_code_fail', {
+        trackGAEvent(GA_EVENTS.VERIFY_CODE_FAIL, {
           signup_step: 'email_verification',
         });
         alert(response.message);
       }
     } catch (error) {
-      trackGAEvent('verify_code_error', {
+      trackGAEvent(GA_EVENTS.VERIFY_CODE_ERROR, {
         signup_step: 'email_verification',
       });
 
@@ -89,7 +90,7 @@ export default function Page() {
   };
 
   const onSubmit = async (data: SignupForm) => {
-    trackGAEvent('signup_submit_attempt', {
+    trackGAEvent(GA_EVENTS.SIGNUP_SUBMIT_ATTEMPT, {
       signup_step: 'final_submit',
     });
     try {
@@ -102,15 +103,15 @@ export default function Page() {
         termsAgreed: data.agree,
       });
       if (response.success) {
-        trackGAEvent('sign_up', {
-          method: 'school_email',
+        trackGAEvent(GA_EVENTS.SIGN_UP, {
+          method: GA_METHODS.SCHOOL_EMAIL,
         });
 
         setUserName(data.name);
         setIsComplete(true);
       }
     } catch (error: unknown) {
-      trackGAEvent('signup_submit_fail', {
+      trackGAEvent(GA_EVENTS.SIGNUP_SUBMIT_FAIL, {
         signup_step: 'final_submit',
       });
       if (error instanceof CustomHttpError && error.status === 400) {

--- a/apps/web/src/common/constants/gaEvents.ts
+++ b/apps/web/src/common/constants/gaEvents.ts
@@ -1,0 +1,34 @@
+export const GA_EVENTS = {
+  GOOGLE_LOGIN_CLICK: 'google_login_click',
+  GOOGLE_SIGNUP_START: 'google_signup_start',
+  LOGIN: 'login',
+  SIGN_UP: 'sign_up',
+
+  EMAIL_REQUEST: 'email_request',
+  EMAIL_SUCCESS: 'email_success',
+  EMAIL_FAIL: 'email_fail',
+  EMAIL_ERROR: 'email_error',
+  VERIFY_CODE_ATTEMPT: 'verify_code_attempt',
+  VERIFY_CODE_SUCCESS: 'verify_code_success',
+  VERIFY_CODE_FAIL: 'verify_code_fail',
+  VERIFY_CODE_ERROR: 'verify_code_error',
+  SIGNUP_SUBMIT_ATTEMPT: 'signup_submit_attempt',
+  SIGNUP_SUBMIT_FAIL: 'signup_submit_fail',
+
+  CLUB_SIGNUP_START: 'club_signup_start',
+  CLUB_SIGNUP_SUBMIT: 'club_signup_submit',
+  CLUB_SIGNUP_SUCCESS: 'club_signup_success',
+
+  APPLY_FORM_VIEW: 'apply_form_view',
+  APPLY_FORM_START: 'apply_form_start',
+  APPLY_TEMP_SAVE_ATTEMPT: 'apply_temp_save_attempt',
+  APPLY_TEMP_SAVE_SUCCESS: 'apply_temp_save_success',
+  APPLY_RESUME: 'apply_resume',
+  APPLY_SUBMIT_ATTEMPT: 'apply_submit_attempt',
+  APPLY_SUBMIT_SUCCESS: 'apply_submit_success',
+} as const;
+
+export const GA_METHODS = {
+  GOOGLE: 'google',
+  SCHOOL_EMAIL: 'school_email',
+} as const;

--- a/apps/web/src/components/admin/clubInfo/clubBoard/BoardFormModal.tsx
+++ b/apps/web/src/components/admin/clubInfo/clubBoard/BoardFormModal.tsx
@@ -22,6 +22,7 @@ interface BoardFormModalProps {
 function BoardFormModal({ clubId, boardId, isSubmitting, onSubmit, onClose }: BoardFormModalProps) {
   const isEditMode = Boolean(boardId);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const scrollAreaRef = useRef<HTMLDivElement>(null);
   const [thumbnail, setThumbnail] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [thumbnailError, setThumbnailError] = useState('');
@@ -40,7 +41,7 @@ function BoardFormModal({ clubId, boardId, isSubmitting, onSubmit, onClose }: Bo
     defaultValues: { title: '' },
   });
 
-  usePreventScroll(true);
+  usePreventScroll(true, scrollAreaRef);
 
   useEffect(() => {
     if (detail) {
@@ -108,7 +109,7 @@ function BoardFormModal({ clubId, boardId, isSubmitting, onSubmit, onClose }: Bo
           </button>
         </div>
 
-        <div className={S.body}>
+        <div ref={scrollAreaRef} className={S.body}>
           <div className={S.field}>
             <div className={S.labelRow}>
               <label htmlFor="boardTitle" className={S.label}>

--- a/apps/web/src/components/admin/clubInfo/clubBoard/boardFormModal.css.ts
+++ b/apps/web/src/components/admin/clubInfo/clubBoard/boardFormModal.css.ts
@@ -110,6 +110,8 @@ export const body = style({
   flex: '1 1 auto',
   minHeight: 0,
   overflowY: 'auto',
+  overscrollBehavior: 'contain',
+  WebkitOverflowScrolling: 'touch',
   display: 'flex',
   flexDirection: 'column',
   gap: '22px',

--- a/apps/web/src/components/admin/signup/page.tsx
+++ b/apps/web/src/components/admin/signup/page.tsx
@@ -12,6 +12,7 @@ import { signupSchema } from './schema';
 import { FILTER_CONFIG } from '@/common/constants';
 import { useState } from 'react';
 import SignupCompletePage from './complete/page';
+import { useClubSignupAnalytics } from '@/hooks/useClubSignupAnalytics';
 
 export type AdminSignupForm = z.infer<typeof signupSchema>;
 
@@ -25,6 +26,7 @@ function SignupPage() {
   });
   const [isComplete, setIsComplete] = useState(false);
   const { handleSignup, signupMutation } = useAdminSignupMutation();
+  const { trackSignupStart, trackSignupSubmit, trackSignupSuccess } = useClubSignupAnalytics();
 
   if (isComplete) {
     return <SignupCompletePage />;
@@ -39,8 +41,11 @@ function SignupPage() {
       </p>
       <form
         className={S.BoxContainer}
+        onChange={trackSignupStart}
         onSubmit={handleSubmit((data) => {
+          trackSignupSubmit();
           handleSignup(data, () => {
+            trackSignupSuccess();
             setIsComplete(true);
           });
         })}

--- a/apps/web/src/components/apply/Form.tsx
+++ b/apps/web/src/components/apply/Form.tsx
@@ -14,6 +14,7 @@ import ConfirmModal from '@/common/components/confirmModal';
 import { useModal } from '@/hooks/useModal';
 import { ROUTES } from '@/common/constants/routes';
 import { TempDataAnswer, Question, TempData } from '@/common/model/form';
+import { useApplyFormAnalytics } from '@/hooks/useApplyFormAnalytics';
 
 const scrollToSection = (sectionId: string) => {
   const element = document.getElementById(sectionId);
@@ -37,17 +38,35 @@ export default function Form({ clubId }: { clubId: string }) {
   const { data: clubData } = useClubInfo(clubId);
   // formId가 있을 때만 임시저장 데이터 조회
   const { data: tempData } = useGetTempData(clubData?.formId || '');
-  const { handlePostForm, isSubmitting } = usePostForm(handleEditModalOpen);
-  const { handlePostTempData } = usePostTempData(handleTempSaveModalOpen);
   const {
     register,
     handleSubmit,
     formState: { errors },
     setValue,
     watch,
+    getValues,
   } = useForm<ApplyFormData>({
     resolver: zodResolver(applyFormSchema),
   });
+
+  const {
+    trackFormStart,
+    trackTempSaveAttempt,
+    trackTempSaveSuccess,
+    trackSubmitAttempt,
+    trackSubmitSuccess,
+  } = useApplyFormAnalytics({
+    clubId,
+    formId: clubData?.formId,
+    questions: clubData?.questions,
+    tempData,
+    getValues,
+  });
+  const { handlePostForm, isSubmitting } = usePostForm(handleEditModalOpen, trackSubmitSuccess);
+  const { handlePostTempData } = usePostTempData(
+    handleTempSaveModalOpen,
+    trackTempSaveSuccess,
+  );
 
   // 질문 데이터가 로드되면 questionId 설정
   React.useEffect(() => {
@@ -274,6 +293,7 @@ export default function Form({ clubId }: { clubId: string }) {
       );
     }
 
+    trackSubmitAttempt();
     handlePostForm(formData, clubId);
   };
 
@@ -352,6 +372,7 @@ export default function Form({ clubId }: { clubId: string }) {
     }
 
     if (clubData?.formId) {
+      trackTempSaveAttempt();
       handlePostTempData(formData, clubData.formId);
     }
   };
@@ -360,9 +381,21 @@ export default function Form({ clubId }: { clubId: string }) {
     console.log('폼 에러:', errors);
   };
 
+  const handleFormChange = (event: React.FormEvent<HTMLFormElement>) => {
+    if (!event.nativeEvent.isTrusted) {
+      return;
+    }
+
+    trackFormStart();
+  };
+
   return (
     <>
-      <form onSubmit={handleSubmit(onSubmit, onError)} className={S.wrapper}>
+      <form
+        onSubmit={handleSubmit(onSubmit, onError)}
+        onChange={handleFormChange}
+        className={S.wrapper}
+      >
         <div className={S.contentContainer}>
           <div className={S.FormHeader}>
             <div className={S.FormTitle}>{clubData?.title} </div>

--- a/apps/web/src/components/apply/Form.tsx
+++ b/apps/web/src/components/apply/Form.tsx
@@ -37,7 +37,7 @@ export default function Form({ clubId }: { clubId: string }) {
   } = useModal();
   const { data: clubData } = useClubInfo(clubId);
   // formId가 있을 때만 임시저장 데이터 조회
-  const { data: tempData } = useGetTempData(clubData?.formId || '');
+  const { data: tempData, isFetched: isTempDataFetched } = useGetTempData(clubData?.formId || '');
   const {
     register,
     handleSubmit,
@@ -60,6 +60,7 @@ export default function Form({ clubId }: { clubId: string }) {
     formId: clubData?.formId,
     questions: clubData?.questions,
     tempData,
+    isTempDataFetched,
     getValues,
   });
   const { handlePostForm, isSubmitting } = usePostForm(handleEditModalOpen, trackSubmitSuccess);

--- a/apps/web/src/components/apply/QuestionsSection.tsx
+++ b/apps/web/src/components/apply/QuestionsSection.tsx
@@ -145,8 +145,9 @@ export default function QuestionsSection({ questions, register, errors }: Questi
           <div key={index} className={S.questionContainer}>
             <div className={S.questionHeader}>
               <div className={S.FormContentTitle}>
-                {question.title}(최대 1GB까지 가능)
+                {question.title}
                 {question.isEssential && <span className={S.FormContentTitleEssential}>*</span>}
+                <span> (최대 1GB까지 가능)</span>
               </div>
               {question.subTitle && (
                 <div className={S.FormContentSubTitle}>{question.subTitle}</div>

--- a/apps/web/src/components/apply/QuestionsSection.tsx
+++ b/apps/web/src/components/apply/QuestionsSection.tsx
@@ -145,7 +145,7 @@ export default function QuestionsSection({ questions, register, errors }: Questi
           <div key={index} className={S.questionContainer}>
             <div className={S.questionHeader}>
               <div className={S.FormContentTitle}>
-                {question.title}
+                {question.title}(최대 1GB까지 가능)
                 {question.isEssential && <span className={S.FormContentTitleEssential}>*</span>}
               </div>
               {question.subTitle && (

--- a/apps/web/src/components/apply/index.css.ts
+++ b/apps/web/src/components/apply/index.css.ts
@@ -1,5 +1,15 @@
-﻿import { style } from '@vanilla-extract/css';
+import { keyframes, style } from '@vanilla-extract/css';
 import { BREAKPOINTS } from '@/common/constants/breakpoints';
+import { vars } from '@/common/styles/theme.css';
+
+const skeletonShimmer = keyframes({
+  '0%': {
+    backgroundPosition: '100% 0',
+  },
+  '100%': {
+    backgroundPosition: '-100% 0',
+  },
+});
 
 export const wrapper = style({
   // paddingLeft: '264px',
@@ -34,3 +44,45 @@ export const container = style({
     },
   },
 });
+
+export const applyHeader = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px',
+  padding: '4px 0 8px',
+});
+
+export const clubName = style({
+  color: vars.colors.charcoal,
+  fontSize: vars.fonts.title3,
+  fontWeight: 700,
+});
+
+export const applyTitle = style({
+  color: vars.colors.surface.outline,
+  fontSize: vars.fonts.body2,
+  fontWeight: 500,
+});
+
+const skeletonBlock = style({
+  borderRadius: '6px',
+  background: 'linear-gradient(90deg, #eef1f5 25%, #f7f8fa 50%, #eef1f5 75%)',
+  backgroundSize: '200% 100%',
+  animation: `${skeletonShimmer} 1.2s ease-in-out infinite`,
+});
+
+export const clubNameSkeleton = style([
+  skeletonBlock,
+  {
+    width: '180px',
+    height: '28px',
+  },
+]);
+
+export const applyTitleSkeleton = style([
+  skeletonBlock,
+  {
+    width: '96px',
+    height: '20px',
+  },
+]);

--- a/apps/web/src/components/faq/faqAccordion.tsx
+++ b/apps/web/src/components/faq/faqAccordion.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { StaticImageData } from 'next/image';
 import * as S from './index.css';
 import FaqItem from './faqItem';
@@ -49,21 +49,76 @@ const FAQ_LIST: FaqItemData[] = [
 export default function FaqAccordion() {
   const [openIndex, setOpenIndex] = useState<number | null>(0);
   const [previewImage, setPreviewImage] = useState<FaqImagePreviewData | null>(null);
+  const previewDialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const previousFocusedElementRef = useRef<HTMLElement | null>(null);
 
   const handleToggle = (index: number) => {
     setOpenIndex((prev) => (prev === index ? null : index));
   };
 
-  const handlePreviewClose = () => {
-    setPreviewImage(null);
+  const handlePreviewOpen = (image: FaqImagePreviewData) => {
+    previousFocusedElementRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    setPreviewImage(image);
   };
+
+  const handlePreviewClose = useCallback(() => {
+    setPreviewImage(null);
+    requestAnimationFrame(() => {
+      previousFocusedElementRef.current?.focus();
+      previousFocusedElementRef.current = null;
+    });
+  }, []);
 
   useEffect(() => {
     if (!previewImage) return;
 
+    closeButtonRef.current?.focus();
+
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         handlePreviewClose();
+        return;
+      }
+
+      if (event.key !== 'Tab') {
+        return;
+      }
+
+      const dialog = previewDialogRef.current;
+      if (!dialog) return;
+
+      const focusableElements = Array.from(
+        dialog.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        ),
+      ).filter((element) => !element.hasAttribute('disabled') && element.tabIndex !== -1);
+
+      if (focusableElements.length === 0) {
+        event.preventDefault();
+        return;
+      }
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+      const activeElement = document.activeElement;
+
+      if (!dialog.contains(activeElement)) {
+        event.preventDefault();
+        firstElement.focus();
+        return;
+      }
+
+      if (event.shiftKey && activeElement === firstElement) {
+        event.preventDefault();
+        lastElement.focus();
+        return;
+      }
+
+      if (!event.shiftKey && activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
       }
     };
 
@@ -72,7 +127,7 @@ export default function FaqAccordion() {
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [previewImage]);
+  }, [previewImage, handlePreviewClose]);
 
   const isDividerVisible = (index: number) =>
     index > 0 && openIndex !== index && openIndex !== index - 1;
@@ -88,21 +143,27 @@ export default function FaqAccordion() {
             isExpanded={openIndex === index}
             showDivider={isDividerVisible(index)}
             onToggle={() => handleToggle(index)}
-            onInstallGuideImageClick={setPreviewImage}
+            onInstallGuideImageClick={handlePreviewOpen}
           />
         ))}
       </div>
       {previewImage && (
         <div
+          ref={previewDialogRef}
           className={S.imagePreviewOverlay}
           role="dialog"
           aria-modal="true"
+          aria-label="설치 가이드 이미지 미리보기"
           onClick={handlePreviewClose}
         >
           <button
+            ref={closeButtonRef}
             type="button"
             className={S.imagePreviewCloseButton}
-            onClick={handlePreviewClose}
+            onClick={(event) => {
+              event.stopPropagation();
+              handlePreviewClose();
+            }}
             aria-label="닫기"
           >
             ×

--- a/apps/web/src/components/faq/faqAccordion.tsx
+++ b/apps/web/src/components/faq/faqAccordion.tsx
@@ -1,9 +1,15 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import type { StaticImageData } from 'next/image';
 import * as S from './index.css';
 import FaqItem from './faqItem';
 import { InstallGuideImagePreloader } from './installGuideSection';
+
+export type FaqImagePreviewData = {
+  src: StaticImageData;
+  alt: string;
+};
 
 export type FaqItemData = {
   question: string;
@@ -42,10 +48,31 @@ const FAQ_LIST: FaqItemData[] = [
 
 export default function FaqAccordion() {
   const [openIndex, setOpenIndex] = useState<number | null>(0);
+  const [previewImage, setPreviewImage] = useState<FaqImagePreviewData | null>(null);
 
   const handleToggle = (index: number) => {
     setOpenIndex((prev) => (prev === index ? null : index));
   };
+
+  const handlePreviewClose = () => {
+    setPreviewImage(null);
+  };
+
+  useEffect(() => {
+    if (!previewImage) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        handlePreviewClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [previewImage]);
 
   const isDividerVisible = (index: number) =>
     index > 0 && openIndex !== index && openIndex !== index - 1;
@@ -61,9 +88,35 @@ export default function FaqAccordion() {
             isExpanded={openIndex === index}
             showDivider={isDividerVisible(index)}
             onToggle={() => handleToggle(index)}
+            onInstallGuideImageClick={setPreviewImage}
           />
         ))}
       </div>
+      {previewImage && (
+        <div
+          className={S.imagePreviewOverlay}
+          role="dialog"
+          aria-modal="true"
+          onClick={handlePreviewClose}
+        >
+          <button
+            type="button"
+            className={S.imagePreviewCloseButton}
+            onClick={handlePreviewClose}
+            aria-label="닫기"
+          >
+            ×
+          </button>
+          <img
+            src={previewImage.src.src}
+            alt={previewImage.alt}
+            width={previewImage.src.width}
+            height={previewImage.src.height}
+            className={S.imagePreview}
+            onClick={(event) => event.stopPropagation()}
+          />
+        </div>
+      )}
     </>
   );
 }

--- a/apps/web/src/components/faq/faqItem.tsx
+++ b/apps/web/src/components/faq/faqItem.tsx
@@ -4,16 +4,23 @@ import Image from 'next/image';
 import * as S from './index.css';
 import ArrowDropDown from '@/assets/dropdown.svg';
 import InstallGuideSection from './installGuideSection';
-import type { FaqItemData } from './faqAccordion';
+import type { FaqImagePreviewData, FaqItemData } from './faqAccordion';
 
 type FaqItemProps = {
   item: FaqItemData;
   isExpanded: boolean;
   showDivider: boolean;
   onToggle: () => void;
+  onInstallGuideImageClick?: (image: FaqImagePreviewData) => void;
 };
 
-export default function FaqItem({ item, isExpanded, showDivider, onToggle }: FaqItemProps) {
+export default function FaqItem({
+  item,
+  isExpanded,
+  showDivider,
+  onToggle,
+  onInstallGuideImageClick,
+}: FaqItemProps) {
   return (
     <div className={S.faqItem({ expanded: isExpanded })}>
       {showDivider && <div className={S.divider} />}
@@ -31,7 +38,9 @@ export default function FaqItem({ item, isExpanded, showDivider, onToggle }: Faq
       {isExpanded && (
         <div className={S.answerWrapper}>
           <p className={S.answerText}>{item.answer}</p>
-          {item.hasInstallGuide && <InstallGuideSection />}
+          {item.hasInstallGuide && (
+            <InstallGuideSection onImageClick={onInstallGuideImageClick} />
+          )}
         </div>
       )}
     </div>

--- a/apps/web/src/components/faq/index.css.ts
+++ b/apps/web/src/components/faq/index.css.ts
@@ -255,19 +255,83 @@ export const installGuideTab = recipe({
   },
 });
 
-export const answerImage = style({
+export const answerImageButton = style({
   display: 'block',
   width: '100%',
   maxWidth: '640px',
-  height: 'auto',
   marginTop: '4px',
+  padding: 0,
+  border: 'none',
+  background: 'transparent',
+  cursor: 'zoom-in',
+
+  '@media': {
+    [`screen and (max-width: ${BREAKPOINTS.tablet}px)`]: {
+      maxWidth: '100%',
+    },
+  },
+});
+
+export const answerImage = style({
+  display: 'block',
+  width: '100%',
+  height: 'auto',
   borderRadius: '8px',
   border: `1px solid ${vars.colors.surface.cont_2}`,
 
   '@media': {
     [`screen and (max-width: ${BREAKPOINTS.tablet}px)`]: {
-      maxWidth: '100%',
       borderRadius: '6px',
     },
   },
+});
+
+export const imagePreviewOverlay = style({
+  position: 'fixed',
+  inset: 0,
+  zIndex: 1000,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '48px 20px',
+  backgroundColor: 'rgba(0, 0, 0, 0.72)',
+  cursor: 'zoom-out',
+});
+
+export const imagePreview = style({
+  display: 'block',
+  width: 'auto',
+  maxWidth: 'min(960px, 92vw)',
+  maxHeight: '86vh',
+  height: 'auto',
+  borderRadius: '8px',
+  backgroundColor: vars.colors.white,
+  boxShadow: '0 18px 60px rgba(0, 0, 0, 0.28)',
+  cursor: 'default',
+
+  '@media': {
+    [`screen and (max-width: ${BREAKPOINTS.tablet}px)`]: {
+      maxWidth: '94vw',
+      maxHeight: '82vh',
+      borderRadius: '6px',
+    },
+  },
+});
+
+export const imagePreviewCloseButton = style({
+  position: 'fixed',
+  top: '20px',
+  right: '20px',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '40px',
+  height: '40px',
+  border: 'none',
+  borderRadius: '50%',
+  backgroundColor: 'rgba(255, 255, 255, 0.92)',
+  color: vars.colors.surface.on_surf,
+  fontSize: '28px',
+  lineHeight: 1,
+  cursor: 'pointer',
 });

--- a/apps/web/src/components/faq/installGuideSection.tsx
+++ b/apps/web/src/components/faq/installGuideSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import type { StaticImageData } from 'next/image';
 import { Button } from '@ttockttock/ui';
 import * as S from './index.css';
 import iosInstallGuideImage from './assets/images/ios-install-guide.webp';
@@ -12,6 +13,14 @@ const INSTALL_GUIDE_OPTIONS = [
 ] as const;
 
 type InstallGuidePlatform = (typeof INSTALL_GUIDE_OPTIONS)[number]['key'];
+type InstallGuideImage = {
+  src: StaticImageData;
+  alt: string;
+};
+
+type InstallGuideSectionProps = {
+  onImageClick?: (image: InstallGuideImage) => void;
+};
 
 export function InstallGuideImagePreloader() {
   return (
@@ -33,7 +42,7 @@ export function InstallGuideImagePreloader() {
   );
 }
 
-export default function InstallGuideSection() {
+export default function InstallGuideSection({ onImageClick }: InstallGuideSectionProps) {
   const [platform, setPlatform] = useState<InstallGuidePlatform>('ios');
   const selectedGuide = INSTALL_GUIDE_OPTIONS.find((option) => option.key === platform)!;
 
@@ -57,13 +66,24 @@ export default function InstallGuideSection() {
           );
         })}
       </div>
-      <img
+      <button
+        type="button"
+        className={S.answerImageButton}
+        onClick={() =>
+          onImageClick?.({
+            src: selectedGuide.image,
+            alt: `${selectedGuide.label} install guide image`,
+          })
+        }
+      >
+        <img
         src={selectedGuide.image.src}
         alt={`${selectedGuide.label} 앱 설치 가이드 이미지`}
         width={selectedGuide.image.width}
         height={selectedGuide.image.height}
         className={S.answerImage}
       />
+      </button>
     </div>
   );
 }

--- a/apps/web/src/components/login/googleLogin/index.tsx
+++ b/apps/web/src/components/login/googleLogin/index.tsx
@@ -134,6 +134,7 @@ export default function GoogleLoginButton({
       logo_alignment: 'center',
       locale: 'ko',
       width: buttonWidth,
+      click_listener: () => trackGAEvent(GA_EVENTS.GOOGLE_LOGIN_CLICK),
     });
   }, [isScriptReady, clientId, slotWidth]);
 
@@ -161,11 +162,7 @@ export default function GoogleLoginButton({
         }}
       />
 
-      <div
-        ref={buttonSlotRef}
-        className={S.ButtonSlot}
-        onClick={() => trackGAEvent(GA_EVENTS.GOOGLE_LOGIN_CLICK)}
-      />
+      <div ref={buttonSlotRef} className={S.ButtonSlot} />
 
       <p className={S.GuideText}>
         구글 계정으로 간편하게 로그인할 수 있어요.

--- a/apps/web/src/components/login/googleLogin/index.tsx
+++ b/apps/web/src/components/login/googleLogin/index.tsx
@@ -3,6 +3,8 @@
 import Script from 'next/script';
 import { useEffect, useRef, useState } from 'react';
 
+import { GA_EVENTS } from '@/common/constants/gaEvents';
+import { trackGAEvent } from '@/lib/ga';
 import * as S from './googleLogin.css';
 
 const GIS_SCRIPT_SRC = 'https://accounts.google.com/gsi/client';
@@ -162,6 +164,7 @@ export default function GoogleLoginButton({
       <div
         ref={buttonSlotRef}
         className={S.ButtonSlot}
+        onClick={() => trackGAEvent(GA_EVENTS.GOOGLE_LOGIN_CLICK)}
       />
 
       <p className={S.GuideText}>

--- a/apps/web/src/components/login/googleOnboarding/googleOnboarding.css.ts
+++ b/apps/web/src/components/login/googleOnboarding/googleOnboarding.css.ts
@@ -7,12 +7,13 @@ export const Container = style({
   justifyContent: 'center',
   alignItems: 'center',
   flexDirection: 'column',
+
   gap: '24px',
   minHeight: 'inherit',
 
   '@media': {
     [`screen and (max-width: ${BREAKPOINTS.tablet}px)`]: {
-      padding: '0 20px',
+      padding: '40px 20px',
       gap: '16px',
     },
   },

--- a/apps/web/src/components/signup/SignupComplete.tsx
+++ b/apps/web/src/components/signup/SignupComplete.tsx
@@ -8,11 +8,22 @@ import { ROUTES } from '@/common/constants/routes';
 
 interface SignupCompleteProps {
   userName: string;
+  onStart?: () => void;
 }
 
-export default function SignupComplete({ userName }: SignupCompleteProps) {
+export default function SignupComplete({ userName, onStart }: SignupCompleteProps) {
   const router = useRouter();
   useConfetti();
+
+  const handleStart = () => {
+    if (onStart) {
+      onStart();
+      return;
+    }
+
+    router.push(ROUTES.HOME);
+  };
+
   return (
     <div className={S.CompleteBox}>
       <div className={S.CompleteTitle}>회원가입 완료!</div>
@@ -24,7 +35,7 @@ export default function SignupComplete({ userName }: SignupCompleteProps) {
       <Button
         variant="primary"
         className={S.CompleteButton}
-        onClick={() => router.push(ROUTES.HOME)}
+        onClick={handleStart}
       >
         시작하기
       </Button>

--- a/apps/web/src/hooks/useAdminSignupMutation.ts
+++ b/apps/web/src/hooks/useAdminSignupMutation.ts
@@ -1,12 +1,9 @@
 'use client';
 import { useMutation } from '@tanstack/react-query';
 import { postAdminSignup, AdminSignupForm } from '@/components/admin/signup/api/signup';
-import { useRouter } from 'next/navigation';
-import { ROUTES } from '@/common/constants/routes';
 import { CustomHttpError } from '@/common/apis/apiClient';
 
 export const useAdminSignupMutation = () => {
-  const router = useRouter();
 
   const signupMutation = useMutation({
     mutationFn: async (signupData: AdminSignupForm) => {

--- a/apps/web/src/hooks/useApplyFormAnalytics.ts
+++ b/apps/web/src/hooks/useApplyFormAnalytics.ts
@@ -10,6 +10,7 @@ interface UseApplyFormAnalyticsParams {
   formId?: string;
   questions?: Question[];
   tempData?: getTempData;
+  isTempDataFetched: boolean;
   getValues: UseFormGetValues<ApplyFormData>;
 }
 
@@ -59,6 +60,7 @@ export const useApplyFormAnalytics = ({
   formId,
   questions = [],
   tempData,
+  isTempDataFetched,
   getValues,
 }: UseApplyFormAnalyticsParams) => {
   const trackedStartFormIds = useRef(new Set<string>());
@@ -70,6 +72,7 @@ export const useApplyFormAnalytics = ({
   // tempData는 이후 임시저장/재조회로 값이 바뀔 수 있으므로, formId가 바뀔 때만 다시 캡처한다.
   if (
     formId &&
+    isTempDataFetched &&
     (!visitTempDataState.current || visitTempDataState.current.formId !== formId)
   ) {
     visitTempDataState.current = {
@@ -78,7 +81,12 @@ export const useApplyFormAnalytics = ({
     };
   }
 
-  const hasTempData = visitTempDataState.current?.hasTempData ?? false;
+  const initialTempDataState = visitTempDataState.current;
+  const isInitialTempDataReady = initialTempDataState?.formId === formId;
+  const hasTempData =
+    initialTempDataState && initialTempDataState.formId === formId
+      ? initialTempDataState.hasTempData
+      : false;
 
   const baseParams = useMemo(
     () => ({
@@ -156,20 +164,28 @@ export const useApplyFormAnalytics = ({
   }, [trackWithCurrentState]);
 
   useEffect(() => {
+    if (!isInitialTempDataReady) {
+      return;
+    }
+
     if (!shouldTrackOnce(trackedViewFormIds.current, formId)) {
       return;
     }
 
     trackGAEvent(GA_EVENTS.APPLY_FORM_VIEW, baseParams);
-  }, [baseParams, formId]);
+  }, [baseParams, formId, isInitialTempDataReady]);
 
   useEffect(() => {
-    if (!tempData?.hasTempData || !shouldTrackOnce(trackedResumeFormIds.current, formId)) {
+    if (
+      !isInitialTempDataReady ||
+      !hasTempData ||
+      !shouldTrackOnce(trackedResumeFormIds.current, formId)
+    ) {
       return;
     }
 
     trackGAEvent(GA_EVENTS.APPLY_RESUME, baseParams);
-  }, [baseParams, formId, tempData?.hasTempData]);
+  }, [baseParams, formId, hasTempData, isInitialTempDataReady]);
 
   return {
     trackFormStart,

--- a/apps/web/src/hooks/useApplyFormAnalytics.ts
+++ b/apps/web/src/hooks/useApplyFormAnalytics.ts
@@ -1,0 +1,181 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import type { UseFormGetValues } from 'react-hook-form';
+import { GA_EVENTS } from '@/common/constants/gaEvents';
+import type { Question, getTempData } from '@/common/model/form';
+import type { ApplyFormData } from '@/components/apply/schema';
+import { trackGAEvent } from '@/lib/ga';
+
+interface UseApplyFormAnalyticsParams {
+  clubId: string;
+  formId?: string;
+  questions?: Question[];
+  tempData?: getTempData;
+  getValues: UseFormGetValues<ApplyFormData>;
+}
+
+const hasValue = (value: unknown): boolean => {
+  if (value === null || value === undefined) {
+    return false;
+  }
+
+  if (typeof value === 'string') {
+    return value.trim() !== '';
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((item: unknown) => item !== false && hasValue(item));
+  }
+
+  if (typeof FileList !== 'undefined' && value instanceof FileList) {
+    return value.length > 0;
+  }
+
+  return true;
+};
+
+// 이 배열의 항목 수가 곧 기본 정보 필드 총 개수다 (완료율 계산에 사용).
+const getBasicFieldValues = (values: ApplyFormData): unknown[] => [
+  values.name,
+  values.age,
+  values.major,
+  values.emailPrefix && values.emailDomain,
+  values.phone,
+  values.studentStatus,
+  values.grade,
+  values.gender,
+];
+
+const shouldTrackOnce = (trackedIds: Set<string>, formId: string | undefined): boolean => {
+  if (!formId || trackedIds.has(formId)) {
+    return false;
+  }
+
+  trackedIds.add(formId);
+  return true;
+};
+
+export const useApplyFormAnalytics = ({
+  clubId,
+  formId,
+  questions = [],
+  tempData,
+  getValues,
+}: UseApplyFormAnalyticsParams) => {
+  const trackedStartFormIds = useRef(new Set<string>());
+  const trackedViewFormIds = useRef(new Set<string>());
+  const trackedResumeFormIds = useRef(new Set<string>());
+  const visitTempDataState = useRef<{ formId: string; hasTempData: boolean } | null>(null);
+
+  // has_temp_data는 폼에 처음 진입했을 때의 임시저장 여부를 고정해서 보고해야 한다.
+  // tempData는 이후 임시저장/재조회로 값이 바뀔 수 있으므로, formId가 바뀔 때만 다시 캡처한다.
+  if (
+    formId &&
+    (!visitTempDataState.current || visitTempDataState.current.formId !== formId)
+  ) {
+    visitTempDataState.current = {
+      formId,
+      hasTempData: Boolean(tempData?.hasTempData),
+    };
+  }
+
+  const hasTempData = visitTempDataState.current?.hasTempData ?? false;
+
+  const baseParams = useMemo(
+    () => ({
+      club_id: clubId,
+      form_id: formId,
+      question_count: questions.length,
+      has_temp_data: hasTempData,
+    }),
+    [clubId, formId, hasTempData, questions.length],
+  );
+
+  const getFormStateParams = useCallback(() => {
+    const values = getValues();
+    const basicFieldValues = getBasicFieldValues(values);
+    const answeredBasicFieldCount = basicFieldValues.filter(hasValue).length;
+
+    const answeredQuestionCount =
+      values.questions?.filter((question) => hasValue(question.value)).length ?? 0;
+    const requiredQuestionIds = new Set(
+      questions.filter((question) => question.isEssential).map((question) => question.questionId),
+    );
+    const requiredAnsweredQuestionCount =
+      values.questions?.filter(
+        (question) => requiredQuestionIds.has(question.questionId) && hasValue(question.value),
+      ).length ?? 0;
+
+    const totalFieldCount = basicFieldValues.length + questions.length;
+    const answeredFieldCount = answeredBasicFieldCount + answeredQuestionCount;
+    const completionRate =
+      totalFieldCount > 0 ? Math.round((answeredFieldCount / totalFieldCount) * 100) : 0;
+
+    return {
+      answered_basic_field_count: answeredBasicFieldCount,
+      answered_question_count: answeredQuestionCount,
+      required_answered_count: basicFieldValues.length + requiredAnsweredQuestionCount,
+      required_total_count: basicFieldValues.length + requiredQuestionIds.size,
+      completion_rate: completionRate,
+    };
+  }, [getValues, questions]);
+
+  const trackWithCurrentState = useCallback(
+    (eventName: string) => {
+      trackGAEvent(eventName, {
+        ...baseParams,
+        ...getFormStateParams(),
+      });
+    },
+    [baseParams, getFormStateParams],
+  );
+
+  const trackFormStart = useCallback(() => {
+    if (!shouldTrackOnce(trackedStartFormIds.current, formId)) {
+      return;
+    }
+
+    trackGAEvent(GA_EVENTS.APPLY_FORM_START, baseParams);
+  }, [baseParams, formId]);
+
+  const trackTempSaveAttempt = useCallback(() => {
+    trackFormStart();
+    trackWithCurrentState(GA_EVENTS.APPLY_TEMP_SAVE_ATTEMPT);
+  }, [trackFormStart, trackWithCurrentState]);
+
+  const trackTempSaveSuccess = useCallback(() => {
+    trackWithCurrentState(GA_EVENTS.APPLY_TEMP_SAVE_SUCCESS);
+  }, [trackWithCurrentState]);
+
+  const trackSubmitAttempt = useCallback(() => {
+    trackFormStart();
+    trackWithCurrentState(GA_EVENTS.APPLY_SUBMIT_ATTEMPT);
+  }, [trackFormStart, trackWithCurrentState]);
+
+  const trackSubmitSuccess = useCallback(() => {
+    trackWithCurrentState(GA_EVENTS.APPLY_SUBMIT_SUCCESS);
+  }, [trackWithCurrentState]);
+
+  useEffect(() => {
+    if (!shouldTrackOnce(trackedViewFormIds.current, formId)) {
+      return;
+    }
+
+    trackGAEvent(GA_EVENTS.APPLY_FORM_VIEW, baseParams);
+  }, [baseParams, formId]);
+
+  useEffect(() => {
+    if (!tempData?.hasTempData || !shouldTrackOnce(trackedResumeFormIds.current, formId)) {
+      return;
+    }
+
+    trackGAEvent(GA_EVENTS.APPLY_RESUME, baseParams);
+  }, [baseParams, formId, tempData?.hasTempData]);
+
+  return {
+    trackFormStart,
+    trackTempSaveAttempt,
+    trackTempSaveSuccess,
+    trackSubmitAttempt,
+    trackSubmitSuccess,
+  };
+};

--- a/apps/web/src/hooks/useClubSignupAnalytics.ts
+++ b/apps/web/src/hooks/useClubSignupAnalytics.ts
@@ -1,0 +1,31 @@
+import { useCallback, useRef } from 'react';
+import { GA_EVENTS } from '@/common/constants/gaEvents';
+import { trackGAEvent } from '@/lib/ga';
+
+export const useClubSignupAnalytics = () => {
+  const hasTrackedSignupStart = useRef(false);
+
+  const trackSignupStart = useCallback(() => {
+    if (hasTrackedSignupStart.current) {
+      return;
+    }
+
+    hasTrackedSignupStart.current = true;
+    trackGAEvent(GA_EVENTS.CLUB_SIGNUP_START);
+  }, []);
+
+  const trackSignupSubmit = useCallback(() => {
+    trackSignupStart();
+    trackGAEvent(GA_EVENTS.CLUB_SIGNUP_SUBMIT);
+  }, [trackSignupStart]);
+
+  const trackSignupSuccess = useCallback(() => {
+    trackGAEvent(GA_EVENTS.CLUB_SIGNUP_SUCCESS);
+  }, []);
+
+  return {
+    trackSignupStart,
+    trackSignupSubmit,
+    trackSignupSuccess,
+  };
+};

--- a/apps/web/src/hooks/useGoogleLogin.ts
+++ b/apps/web/src/hooks/useGoogleLogin.ts
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { CustomHttpError } from '@/common/apis/apiClient';
 import { HTTP_STATUS } from '@/common/constants/httpStatus';
+import { GA_EVENTS, GA_METHODS } from '@/common/constants/gaEvents';
 import { MESSAGE } from '@/common/constants/message';
 import { ROUTES } from '@/common/constants/routes';
 import { postGoogleLogin, postGoogleOnboarding } from '@/components/login/api/google';
@@ -28,6 +29,7 @@ const getLoginErrorMessage = (error: unknown) => {
 export const useGoogleLogin = () => {
   const router = useRouter();
   const [onboarding, setOnboarding] = useState<OnboardingState | null>(null);
+  const [completedSignupName, setCompletedSignupName] = useState('');
   const [isPending, setIsPending] = useState(false);
 
   const completeLogin = useCallback(() => {
@@ -47,16 +49,18 @@ export const useGoogleLogin = () => {
       }
 
       setIsPending(true);
+      setCompletedSignupName('');
       try {
         const response = await postGoogleLogin(idToken);
 
         if (response.data.needsOnboarding) {
           const { onboardingToken, email, suggestedName } = response.data;
           setOnboarding({ onboardingToken, email, suggestedName });
+          trackGAEvent(GA_EVENTS.GOOGLE_SIGNUP_START, { method: GA_METHODS.GOOGLE });
           return;
         }
 
-        trackGAEvent('login', { method: 'google' });
+        trackGAEvent(GA_EVENTS.LOGIN, { method: GA_METHODS.GOOGLE });
         completeLogin();
       } catch (error) {
         console.error('구글 로그인 실패:', error);
@@ -70,6 +74,7 @@ export const useGoogleLogin = () => {
 
   const cancelOnboarding = useCallback(() => {
     setOnboarding(null);
+    setCompletedSignupName('');
   }, []);
 
   /** 약관 동의 + 이름을 제출해 가입을 마친다. 온보딩 토큰이 만료되면 구글 로그인부터 다시 시작한다. */
@@ -87,8 +92,9 @@ export const useGoogleLogin = () => {
           name,
         });
 
-        trackGAEvent('sign_up', { method: 'google' });
-        completeLogin();
+        trackGAEvent(GA_EVENTS.SIGN_UP, { method: GA_METHODS.GOOGLE });
+        setCompletedSignupName(name);
+        setOnboarding(null);
       } catch (error) {
         console.error('구글 회원가입 실패:', error);
 
@@ -108,14 +114,16 @@ export const useGoogleLogin = () => {
         setIsPending(false);
       }
     },
-    [completeLogin, onboarding],
+    [onboarding],
   );
 
   return {
     onboarding,
+    completedSignupName,
     isPending,
     handleCredential,
     submitOnboarding,
     cancelOnboarding,
+    completeLogin,
   };
 };

--- a/apps/web/src/hooks/useUserForm.ts
+++ b/apps/web/src/hooks/useUserForm.ts
@@ -22,11 +22,11 @@ export const useClubInfo = (clubId: string) => {
 export const useGetTempData = (formId: string) => {
   const { userTempData } = userTempDataKey;
 
-  const { data } = useSuspenseQuery({
+  const { data, isFetched } = useSuspenseQuery({
     queryKey: [userTempData, formId],
     queryFn: () => getFormData(formId),
   });
-  return { data };
+  return { data, isFetched };
 };
 
 export const usePostForm = (handleEditModalOpen: () => void, onSuccess?: () => void) => {

--- a/apps/web/src/hooks/useUserForm.ts
+++ b/apps/web/src/hooks/useUserForm.ts
@@ -29,7 +29,7 @@ export const useGetTempData = (formId: string) => {
   return { data };
 };
 
-export const usePostForm = (handleEditModalOpen: () => void) => {
+export const usePostForm = (handleEditModalOpen: () => void, onSuccess?: () => void) => {
   const queryClient = useQueryClient();
   const { appliedClubList } = userKey;
 
@@ -37,6 +37,7 @@ export const usePostForm = (handleEditModalOpen: () => void) => {
     mutationFn: ({ body, clubId }: { body: FormData; clubId: string }) =>
       postFormInfo(body, clubId),
     onSuccess: () => {
+      onSuccess?.();
       handleEditModalOpen();
       queryClient.invalidateQueries({ queryKey: appliedClubList });
     },
@@ -60,7 +61,7 @@ export const usePostForm = (handleEditModalOpen: () => void) => {
   return { handlePostForm, isSubmitting: postFormMutation.isPending };
 };
 
-export const usePostTempData = (handleTempSaveModalOpen: () => void) => {
+export const usePostTempData = (handleTempSaveModalOpen: () => void, onSuccess?: () => void) => {
   const queryClient = useQueryClient();
   const { userTempData } = userTempDataKey;
 
@@ -68,6 +69,7 @@ export const usePostTempData = (handleTempSaveModalOpen: () => void) => {
     mutationFn: ({ body, formId }: { body: FormData; formId: string }) =>
       postFormTempData(body, formId),
     onSuccess: (_data: unknown, variables: { body: FormData; formId: string }) => {
+      onSuccess?.();
       handleTempSaveModalOpen();
       queryClient.invalidateQueries({ queryKey: [userTempData, variables.formId] });
     },


### PR DESCRIPTION
### 작업 내용

- [x] GA_EVENTS / GA_METHODS 상수를 새로 만들어 회원가입·구글 로그인·동아리 가입·지원폼 작성 전반에 흩어져 있던 이벤트명 하드코딩 문자열을 중앙화 (오타 방지, 재사용성 확보)
- [x] `useApplyFormAnalytics`, `useClubSignupAnalytics` 훅을 새로 구현해 지원폼 작성 퍼널(조회 → 시작 → 임시저장 → 제출)과 동아리 관리자 회원가입 퍼널을 추적. 폼 진입 시 임시저장 여부(`has_temp_data`)는 최초 1회만 캡처해 이후 값 변경에 영향받지 않도록 처리
- [x] 구글 로그인 온보딩 완료 후 바로 로그인 처리하던 것을 `SignupComplete` 화면을 거치도록 변경 (`useGoogleLogin`에 `completedSignupName` 상태 추가)
- [x] FAQ 설치 가이드 이미지 클릭 시 확대 미리보기 모달 추가 (Esc / 오버레이 클릭으로 닫기)
- [x] 지원폼 페이지 로딩 중 스켈레톤 UI 추가, 파일 첨부 질문에 "최대 1GB까지 가능" 안내 문구 추가
- [x] `BoardFormModal`의 `usePreventScroll`에 모달 내부 스크롤 영역 ref를 전달해, 배경 스크롤만 막고 모달 내부 스크롤은 허용하도록 개선
- [x] 사용하지 않는 주석 처리 코드 및 미사용 `useRouter` 정리 (apply page, login page, `useAdminSignupMutation`)
- GA 이벤트 값(문자열) 자체는 기존과 동일하게 유지하며 상수로만 옮겼는지 확인 부탁드립니다. 특이사항은 없습니다.
- 리뷰어는 `useApplyFormAnalytics`의 완료율(`completion_rate`) 계산 로직과, `useGoogleLogin`의 온보딩 완료 후 상태 흐름 변경(`completedSignupName` 도입) 부분을 중점적으로 봐주시면 좋겠습니다
- GA 이벤트 네이밍/파라미터 스펙이 기획 의도와 맞게 설계됐는지, `completion_rate` 계산 방식이 요구사항과 일치하는지 논의하고 싶습니다

### 📸 스크린샷

| As-is | To-be |
| ----- | ----- |
|       |       |

### 연관 이슈

close #326 #343


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Google 로그인 후 신규 가입 완료 화면을 표시하고, 이름 확인 후 로그인을 이어갈 수 있습니다.
  * FAQ 설치 가이드 이미지를 클릭해 전체 화면으로 확대하고 닫을 수 있습니다.
  * 지원서 파일 항목에 최대 1GB 업로드 안내가 추가되었습니다.
  * 지원서 임시저장·제출 및 동아리 가입 진행 상황을 분석합니다.

* **개선 사항**
  * 지원서 화면에 로딩 스켈레톤과 반응형 스타일이 적용되었습니다.
  * 모바일·태블릿 환경의 화면 여백과 모달 스크롤 동작이 개선되었습니다.
  * Google 로그인 및 이메일 인증 관련 분석 기록이 일관되게 관리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->