### PR TITLE
질문 항목 삭제 버튼을 더보기 드롭다운으로 개선(issue #345)

### DIFF
--- a/apps/web/src/components/admin/applicationForm/createform/step3/index.tsx
+++ b/apps/web/src/components/admin/applicationForm/createform/step3/index.tsx
@@ -19,7 +19,8 @@ function FormQuestionStep() {
     previousStepData,
     setQeustionsData,
     handleQuestionTypeChange,
-    handleAddField,
+    handleAddField: addField,
+    handleAddFieldBelow: addFieldBelow,
     handleUpdateField,
     handleDeleteField,
     handleEssentialChange,
@@ -34,10 +35,28 @@ function FormQuestionStep() {
   const { result, errors } = useApplicationFormValidation(questionsData);
   const scrollRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
-  const handleScrollTo = (index: number) => {
-    const questionId = questionsData.questions[index]?.questionId ?? index.toString();
+  const scrollToQuestion = (questionId: string) => {
     const target = scrollRefs.current[questionId];
     if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  const handleScrollTo = (index: number) => {
+    const questionId = questionsData.questions[index]?.questionId ?? index.toString();
+    scrollToQuestion(questionId);
+  };
+
+  const handleAddFieldBelow = (fieldId: string) => {
+    const newFieldId = addFieldBelow(fieldId);
+    requestAnimationFrame(() => {
+      scrollToQuestion(newFieldId);
+    });
+  };
+
+  const handleAddField = (param?: { newField?: ApplyFormField }) => {
+    const newFieldId = addField(param);
+    requestAnimationFrame(() => {
+      scrollToQuestion(newFieldId);
+    });
   };
 
   const handleReorderQuestions = (newOrder: ApplyFormField[]) => {
@@ -75,6 +94,7 @@ function FormQuestionStep() {
         handleUpdateField={handleUpdateField}
         scrollRefs={scrollRefs}
         handleDeleteField={handleDeleteField}
+        handleAddFieldBelow={handleAddFieldBelow}
         handleEssentialChange={handleEssentialChange}
         handleOptionChange={handleOptionChange}
         handleOptionAdd={handleOptionAdd}

--- a/apps/web/src/components/admin/applicationForm/index.tsx
+++ b/apps/web/src/components/admin/applicationForm/index.tsx
@@ -29,6 +29,7 @@ function ApplicationFormPage() {
     setQeustionsData,
     handleQuestionTypeChange,
     handleAddField,
+    handleAddFieldBelow: addFieldBelow,
     handleUpdateField,
     handleDeleteField,
     handleEssentialChange,
@@ -45,10 +46,21 @@ function ApplicationFormPage() {
   const { isOpen, handleModalClose, handleModalOpen } = useModal();
   const scrollRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
-  const handleScrollTo = (index: number) => {
-    const questionId = questionsData.questions[index]?.questionId ?? index.toString();
+  const scrollToQuestion = (questionId: string) => {
     const target = scrollRefs.current[questionId];
     if (target) target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  };
+
+  const handleScrollTo = (index: number) => {
+    const questionId = questionsData.questions[index]?.questionId ?? index.toString();
+    scrollToQuestion(questionId);
+  };
+
+  const handleAddFieldBelow = (fieldId: string) => {
+    const newFieldId = addFieldBelow(fieldId);
+    requestAnimationFrame(() => {
+      scrollToQuestion(newFieldId);
+    });
   };
 
   const mergeFormData = {
@@ -117,6 +129,7 @@ function ApplicationFormPage() {
             handleAddField={handleAddField}
             handleUpdateField={handleUpdateField}
             handleDeleteField={handleDeleteField}
+            handleAddFieldBelow={handleAddFieldBelow}
             handleEssentialChange={handleEssentialChange}
             handleOptionChange={handleOptionChange}
             handleOptionAdd={handleOptionAdd}

--- a/apps/web/src/components/admin/applicationForm/questionForm/checkboxField.tsx
+++ b/apps/web/src/components/admin/applicationForm/questionForm/checkboxField.tsx
@@ -4,10 +4,10 @@ import DropDown from '@/common/components/dropdown';
 import DropDownButton from '@/common/ui/dropdownButton';
 import Checkbox from '@/common/ui/checkbox';
 import Image from 'next/image';
-import Delete from '@/assets/delete.svg';
 import AddFeild from '@/assets/add_circle.svg';
 import DeleteOption from '@/assets/option_delete.svg';
 import check from '@/assets/check_radio.svg';
+import moreVert from '@/assets/more_vert.svg';
 
 import { QuestionStepForm, ApplyFormField, QuestionType } from '@/common/model/applicationForm';
 import { questionTypes } from './index';
@@ -24,6 +24,7 @@ interface InputFieldProps {
   handleQuestionTypeChange: (type: QuestionType) => void;
   handleUpdateField: (fieldId: string, data: ApplyFormField) => void;
   handleDeleteField: (fieldId: string) => void;
+  handleAddFieldBelow: (fieldId: string) => void;
   handleEssentialChange: (fieldId: string, isEssential: boolean) => void;
   handleOptionChange: (fieldId: string, optionIndex: number, value: string) => void;
   handleOptionAdd: (fieldId: string) => void;
@@ -40,6 +41,7 @@ function CheckboxField({
   handleQuestionTypeChange,
   handleUpdateField,
   handleDeleteField,
+  handleAddFieldBelow,
   handleEssentialChange,
   handleOptionChange,
   handleOptionAdd,
@@ -90,12 +92,22 @@ function CheckboxField({
             onChange={(e) => handleEssentialChange(fieldId, e.target.checked)}
           />
           <span className={S.horizonLine} />
-          <Image
-            src={Delete}
-            alt="항목 삭제하기"
-            className={S.deleteButton}
-            onClick={() => handleDeleteField(fieldId)}
-          />
+          <DropDown
+            toggleButton={
+              <Image src={moreVert} alt="항목 옵션 더보기" className={S.fieldOptionButton} />
+            }
+            panelClassName={S.fieldOptionList}
+          >
+            <li className={S.fieldOptionItem} onClick={() => handleAddFieldBelow(fieldId)}>
+              아래에 질문 추가
+            </li>
+            <li
+              className={`${S.fieldOptionItem} ${S.fieldOptionItemDelete}`}
+              onClick={() => handleDeleteField(fieldId)}
+            >
+              삭제
+            </li>
+          </DropDown>
         </div>
       </div>
 

--- a/apps/web/src/components/admin/applicationForm/questionForm/fileField.tsx
+++ b/apps/web/src/components/admin/applicationForm/questionForm/fileField.tsx
@@ -6,7 +6,7 @@ import Checkbox from '@/common/ui/checkbox';
 import Image from 'next/image';
 import { questionTypes } from './index';
 import check from '@/assets/check_radio.svg';
-import Delete from '@/assets/delete.svg';
+import moreVert from '@/assets/more_vert.svg';
 import { QuestionStepForm, ApplyFormField, QuestionType } from '@/common/model/applicationForm';
 import { convertToKor } from '@/common/util/convertToKor';
 import { ZodFormattedError } from 'zod';
@@ -20,6 +20,7 @@ interface InputFieldProps {
   handleQuestionTypeChange: (type: QuestionType) => void;
   handleUpdateField: (fieldId: string, data: ApplyFormField) => void;
   handleDeleteField: (fieldId: string) => void;
+  handleAddFieldBelow: (fieldId: string) => void;
   handleEssentialChange: (fieldId: string, isEssential: boolean) => void;
 }
 
@@ -33,6 +34,7 @@ function FileField({
   handleQuestionTypeChange,
   handleUpdateField,
   handleDeleteField,
+  handleAddFieldBelow,
   handleEssentialChange,
 }: InputFieldProps) {
   const titleErrorMessage = errors?.questions?.[fieldIndex]?.title?._errors[0];
@@ -80,12 +82,22 @@ function FileField({
             onChange={(e) => handleEssentialChange(fieldId, e.target.checked)}
           />
           <span className={S.horizonLine} />
-          <Image
-            src={Delete}
-            alt="항목 삭제하기"
-            className={S.deleteButton}
-            onClick={() => handleDeleteField(fieldId)}
-          />
+          <DropDown
+            toggleButton={
+              <Image src={moreVert} alt="항목 옵션 더보기" className={S.fieldOptionButton} />
+            }
+            panelClassName={S.fieldOptionList}
+          >
+            <li className={S.fieldOptionItem} onClick={() => handleAddFieldBelow(fieldId)}>
+              아래에 질문 추가
+            </li>
+            <li
+              className={`${S.fieldOptionItem} ${S.fieldOptionItemDelete}`}
+              onClick={() => handleDeleteField(fieldId)}
+            >
+              삭제
+            </li>
+          </DropDown>
         </div>
       </div>
 

--- a/apps/web/src/components/admin/applicationForm/questionForm/index.tsx
+++ b/apps/web/src/components/admin/applicationForm/questionForm/index.tsx
@@ -27,6 +27,7 @@ interface QuestionFormProps {
   handleQuestionTypeChange: (type: QuestionType, index: string) => void;
   handleUpdateField: (fieldId: string, data: ApplyFormField) => void;
   handleDeleteField: (fieldId: string) => void;
+  handleAddFieldBelow: (fieldId: string) => void;
   handleEssentialChange: (fieldId: string, isEssential: boolean) => void;
   handleOptionChange: (fieldId: string, optionIndex: number, value: string) => void;
   handleOptionAdd: (fieldId: string) => void;
@@ -46,6 +47,7 @@ function QuestionForm({
   handleQuestionTypeChange,
   handleUpdateField,
   handleDeleteField,
+  handleAddFieldBelow,
   handleEssentialChange,
   handleOptionChange,
   handleOptionAdd,
@@ -122,6 +124,7 @@ function QuestionForm({
                 isSubmit={isSubmit}
                 handleUpdateField={handleUpdateField}
                 handleDeleteField={handleDeleteField}
+                handleAddFieldBelow={handleAddFieldBelow}
                 handleEssentialChange={handleEssentialChange}
                 handleOptionChange={handleOptionChange}
                 handleOptionAdd={handleOptionAdd}

--- a/apps/web/src/components/admin/applicationForm/questionForm/inputField.tsx
+++ b/apps/web/src/components/admin/applicationForm/questionForm/inputField.tsx
@@ -5,8 +5,8 @@ import DropDownButton from '@/common/ui/dropdownButton';
 import Checkbox from '@/common/ui/checkbox';
 import Image from 'next/image';
 import { questionTypes } from './index';
-import Delete from '@/assets/delete.svg';
 import check from '@/assets/check_radio.svg';
+import moreVert from '@/assets/more_vert.svg';
 import { QuestionStepForm, ApplyFormField, QuestionType } from '@/common/model/applicationForm';
 import { convertToKor } from '@/common/util/convertToKor';
 import { ZodFormattedError } from 'zod';
@@ -20,6 +20,7 @@ interface InputFieldProps {
   handleQuestionTypeChange: (type: QuestionType) => void;
   handleUpdateField: (fieldId: string, data: ApplyFormField) => void;
   handleDeleteField: (fieldId: string) => void;
+  handleAddFieldBelow: (fieldId: string) => void;
   handleEssentialChange: (fieldId: string, isEssential: boolean) => void;
 }
 
@@ -33,6 +34,7 @@ function InputField({
   handleQuestionTypeChange,
   handleUpdateField,
   handleDeleteField,
+  handleAddFieldBelow,
   handleEssentialChange,
 }: InputFieldProps) {
   const titleErrorMessage = errors?.questions?.[fieldIndex]?.title?._errors[0];
@@ -80,12 +82,22 @@ function InputField({
             onChange={(e) => handleEssentialChange(fieldId, e.target.checked)}
           />
           <span className={S.horizonLine} />
-          <Image
-            src={Delete}
-            alt="항목 삭제하기"
-            className={S.deleteButton}
-            onClick={() => handleDeleteField(fieldId)}
-          />
+          <DropDown
+            toggleButton={
+              <Image src={moreVert} alt="항목 옵션 더보기" className={S.fieldOptionButton} />
+            }
+            panelClassName={S.fieldOptionList}
+          >
+            <li className={S.fieldOptionItem} onClick={() => handleAddFieldBelow(fieldId)}>
+              아래에 질문 추가
+            </li>
+            <li
+              className={`${S.fieldOptionItem} ${S.fieldOptionItemDelete}`}
+              onClick={() => handleDeleteField(fieldId)}
+            >
+              삭제
+            </li>
+          </DropDown>
         </div>
       </div>
 

--- a/apps/web/src/components/admin/applicationForm/questionForm/questionFactory.tsx
+++ b/apps/web/src/components/admin/applicationForm/questionForm/questionFactory.tsx
@@ -16,6 +16,7 @@ interface FormFieldFactoryProps {
   handleQuestionTypeChange: (type: QuestionType) => void;
   handleUpdateField: (fieldId: string, data: ApplyFormField) => void;
   handleDeleteField: (fieldId: string) => void;
+  handleAddFieldBelow: (fieldId: string) => void;
   handleEssentialChange: (fieldId: string, isEssential: boolean) => void;
   handleOptionChange: (fieldId: string, optionIndex: number, value: string) => void;
   handleOptionAdd: (fieldId: string) => void;
@@ -32,6 +33,7 @@ function FormFieldFactory({
   handleQuestionTypeChange,
   handleUpdateField,
   handleDeleteField,
+  handleAddFieldBelow,
   handleEssentialChange,
   handleOptionChange,
   handleOptionAdd,
@@ -50,6 +52,7 @@ function FormFieldFactory({
           handleQuestionTypeChange={handleQuestionTypeChange}
           handleUpdateField={handleUpdateField}
           handleDeleteField={handleDeleteField}
+          handleAddFieldBelow={handleAddFieldBelow}
           handleEssentialChange={handleEssentialChange}
         />
       );
@@ -65,6 +68,7 @@ function FormFieldFactory({
           handleQuestionTypeChange={handleQuestionTypeChange}
           handleUpdateField={handleUpdateField}
           handleDeleteField={handleDeleteField}
+          handleAddFieldBelow={handleAddFieldBelow}
           handleEssentialChange={handleEssentialChange}
         />
       );
@@ -80,6 +84,7 @@ function FormFieldFactory({
           handleQuestionTypeChange={handleQuestionTypeChange}
           handleUpdateField={handleUpdateField}
           handleDeleteField={handleDeleteField}
+          handleAddFieldBelow={handleAddFieldBelow}
           handleEssentialChange={handleEssentialChange}
           handleOptionChange={handleOptionChange}
           handleOptionAdd={handleOptionAdd}
@@ -99,6 +104,7 @@ function FormFieldFactory({
           handleQuestionTypeChange={handleQuestionTypeChange}
           handleUpdateField={handleUpdateField}
           handleDeleteField={handleDeleteField}
+          handleAddFieldBelow={handleAddFieldBelow}
           handleEssentialChange={handleEssentialChange}
           handleOptionChange={handleOptionChange}
           handleOptionAdd={handleOptionAdd}
@@ -118,6 +124,7 @@ function FormFieldFactory({
           handleQuestionTypeChange={handleQuestionTypeChange}
           handleUpdateField={handleUpdateField}
           handleDeleteField={handleDeleteField}
+          handleAddFieldBelow={handleAddFieldBelow}
           handleEssentialChange={handleEssentialChange}
         />
       );

--- a/apps/web/src/components/admin/applicationForm/questionForm/questionFrom.css.ts
+++ b/apps/web/src/components/admin/applicationForm/questionForm/questionFrom.css.ts
@@ -247,14 +247,50 @@ export const horizonLine = style({
   },
 });
 
-export const deleteButton = style({
+export const fieldOptionButton = style({
   cursor: 'pointer',
   '@media': {
     [`screen and (max-width: ${BREAKPOINTS.desktop - 1}px)`]: {
-      width: '24px',
-      height: '24px',
+      width: '20px',
+      height: '20px',
     },
   },
+});
+
+export const fieldOptionList = style({
+  width: '140px',
+  '@media': {
+    [`screen and (max-width: ${BREAKPOINTS.desktop - 1}px)`]: {
+      width: '120px',
+    },
+  },
+});
+
+export const fieldOptionItem = style({
+  width: '100%',
+  cursor: 'pointer',
+  color: vars.colors.surface.on_surf,
+  fontSize: vars.fonts.body2,
+  fontWeight: 600,
+  textAlign: 'left',
+  padding: '12px 20px',
+  whiteSpace: 'nowrap',
+  selectors: {
+    '&:hover': {
+      backgroundColor: vars.colors.primary.base,
+      color: vars.colors.primary.default,
+    },
+  },
+  '@media': {
+    [`screen and (max-width: ${BREAKPOINTS.desktop - 1}px)`]: {
+      padding: '10px 12px',
+      fontSize: vars.fonts.m_body1,
+    },
+  },
+});
+
+export const fieldOptionItemDelete = style({
+  color: vars.colors.error.primary,
 });
 
 export const questionTitle = recipe({

--- a/apps/web/src/components/admin/applicationForm/questionForm/radioField.tsx
+++ b/apps/web/src/components/admin/applicationForm/questionForm/radioField.tsx
@@ -6,8 +6,8 @@ import Checkbox from '@/common/ui/checkbox';
 import Image from 'next/image';
 import check from '@/assets/check_radio.svg';
 import AddFeild from '@/assets/add_circle.svg';
-import Delete from '@/assets/delete.svg';
 import DeleteOption from '@/assets/option_delete.svg';
+import moreVert from '@/assets/more_vert.svg';
 import { questionTypes } from './index';
 
 import { QuestionStepForm, ApplyFormField, QuestionType } from '@/common/model/applicationForm';
@@ -23,6 +23,7 @@ interface InputFieldProps {
   handleQuestionTypeChange: (type: QuestionType) => void;
   handleUpdateField: (fieldId: string, data: ApplyFormField) => void;
   handleDeleteField: (fieldId: string) => void;
+  handleAddFieldBelow: (fieldId: string) => void;
   handleEssentialChange: (fieldId: string, isEssential: boolean) => void;
   handleOptionChange: (fieldId: string, optionIndex: number, value: string) => void;
   handleOptionAdd: (fieldId: string) => void;
@@ -39,6 +40,7 @@ function RadioField({
   handleQuestionTypeChange,
   handleUpdateField,
   handleDeleteField,
+  handleAddFieldBelow,
   handleEssentialChange,
   handleOptionChange,
   handleOptionAdd,
@@ -89,12 +91,22 @@ function RadioField({
             onChange={(e) => handleEssentialChange(fieldId, e.target.checked)}
           />
           <span className={S.horizonLine} />
-          <Image
-            src={Delete}
-            alt="항목 삭제하기"
-            className={S.deleteButton}
-            onClick={() => handleDeleteField(fieldId)}
-          />
+          <DropDown
+            toggleButton={
+              <Image src={moreVert} alt="항목 옵션 더보기" className={S.fieldOptionButton} />
+            }
+            panelClassName={S.fieldOptionList}
+          >
+            <li className={S.fieldOptionItem} onClick={() => handleAddFieldBelow(fieldId)}>
+              아래에 질문 추가
+            </li>
+            <li
+              className={`${S.fieldOptionItem} ${S.fieldOptionItemDelete}`}
+              onClick={() => handleDeleteField(fieldId)}
+            >
+              삭제
+            </li>
+          </DropDown>
         </div>
       </div>
 

--- a/apps/web/src/components/admin/applicationForm/questionForm/textAreaField.tsx
+++ b/apps/web/src/components/admin/applicationForm/questionForm/textAreaField.tsx
@@ -4,8 +4,8 @@ import DropDown from '@/common/components/dropdown';
 import DropDownButton from '@/common/ui/dropdownButton';
 import Checkbox from '@/common/ui/checkbox';
 import Image from 'next/image';
-import Delete from '@/assets/delete.svg';
 import check from '@/assets/check_radio.svg';
+import moreVert from '@/assets/more_vert.svg';
 import { questionTypes } from './index';
 
 import { QuestionStepForm, ApplyFormField, QuestionType } from '@/common/model/applicationForm';
@@ -21,6 +21,7 @@ interface InputFieldProps {
   handleQuestionTypeChange: (type: QuestionType) => void;
   handleUpdateField: (fieldId: string, data: ApplyFormField) => void;
   handleDeleteField: (fieldId: string) => void;
+  handleAddFieldBelow: (fieldId: string) => void;
   handleEssentialChange: (fieldId: string, isEssential: boolean) => void;
 }
 
@@ -33,6 +34,7 @@ function TextAreaField({
   handleQuestionTypeChange,
   handleUpdateField,
   handleDeleteField,
+  handleAddFieldBelow,
   handleEssentialChange,
   scrollRefs,
 }: InputFieldProps) {
@@ -81,12 +83,22 @@ function TextAreaField({
             onChange={(e) => handleEssentialChange(fieldId, e.target.checked)}
           />
           <span className={S.horizonLine} />
-          <Image
-            src={Delete}
-            alt="항목 삭제하기"
-            className={S.deleteButton}
-            onClick={() => handleDeleteField(fieldId)}
-          />
+          <DropDown
+            toggleButton={
+              <Image src={moreVert} alt="항목 옵션 더보기" className={S.fieldOptionButton} />
+            }
+            panelClassName={S.fieldOptionList}
+          >
+            <li className={S.fieldOptionItem} onClick={() => handleAddFieldBelow(fieldId)}>
+              아래에 질문 추가
+            </li>
+            <li
+              className={`${S.fieldOptionItem} ${S.fieldOptionItemDelete}`}
+              onClick={() => handleDeleteField(fieldId)}
+            >
+              삭제
+            </li>
+          </DropDown>
         </div>
       </div>
 

--- a/apps/web/src/hooks/useApplicationForm.ts
+++ b/apps/web/src/hooks/useApplicationForm.ts
@@ -48,30 +48,23 @@ export const useApplicationForm = () => {
   };
 
   const handleAddField = ({ newField }: { newField?: ApplyFormField } = {}) => {
-    if (newField) {
-      setQeustionsData((prev) => ({
-        ...prev,
-        questions: [
-          ...prev.questions,
-          { ...newField, questionId: newField.questionId ?? generateTempId() },
-        ],
-      }));
-      return;
-    }
-
-    const newBaseField = {
-      questionId: generateTempId(),
-      title: '',
-      subTitle: '',
-      questionType: 'SHORT_ANSWER' as QuestionType,
-      isEssential: false,
-      content: [''],
-    };
+    const fieldToAdd: ApplyFormField = newField
+      ? { ...newField, questionId: generateTempId() }
+      : {
+          questionId: generateTempId(),
+          title: '',
+          subTitle: '',
+          questionType: 'SHORT_ANSWER' as QuestionType,
+          isEssential: false,
+          content: [''],
+        };
 
     setQeustionsData((prev) => ({
       ...prev,
-      questions: [...prev.questions, newBaseField],
+      questions: [...prev.questions, fieldToAdd],
     }));
+
+    return fieldToAdd.questionId as string;
   };
 
   const handleUpdateField = (fieldId: string, updatedField: ApplyFormField) => {
@@ -83,6 +76,32 @@ export const useApplicationForm = () => {
       );
       return { ...prev, questions: newQuestions };
     });
+  };
+
+  const handleAddFieldBelow = (fieldId: string) => {
+    const newField: ApplyFormField = {
+      questionId: generateTempId(),
+      title: '',
+      subTitle: '',
+      questionType: 'SHORT_ANSWER' as QuestionType,
+      isEssential: false,
+      content: [''],
+    };
+
+    setQeustionsData((prev) => {
+      const targetIndex = prev.questions.findIndex((q, index) =>
+        isSameField(q, index, fieldId),
+      );
+      if (targetIndex === -1) {
+        return { ...prev, questions: [...prev.questions, newField] };
+      }
+
+      const newQuestions = [...prev.questions];
+      newQuestions.splice(targetIndex + 1, 0, newField);
+      return { ...prev, questions: newQuestions };
+    });
+
+    return newField.questionId as string;
   };
 
   const handleDeleteField = (fieldId: string) => {
@@ -160,6 +179,7 @@ export const useApplicationForm = () => {
     setQeustionsData,
     handleQuestionTypeChange,
     handleAddField,
+    handleAddFieldBelow,
     handleUpdateField,
     handleDeleteField,
     handleEssentialChange,


### PR DESCRIPTION
### 작업 내용

- 지원폼 관리자 화면의 각 질문 항목 툴바에서 항목 삭제 아이콘을 클릭하면 바로 삭제되던 기존 방식을, `⋮`(더보기) 버튼을 눌러 "아래에 질문 추가" / "삭제" 옵션이 있는 드롭다운 패널로 노출하도록 변경
- 드롭다운 패널 텍스트는 왼쪽 정렬로 통일하고, 기존 다른 드롭다운과 동일한 기준(`BREAKPOINTS.desktop`)으로 모바일 반응형 스타일 추가
- "아래에 질문 추가" 선택 시 해당 위치 바로 다음에 새 질문을 추가하고, 렌더링 완료 후 새로 추가된 질문 섹션으로 자동 스크롤되도록 `useApplicationForm`에 `handleAddFieldBelow`를 추가
- 추천 질문 템플릿(자기소개/지원동기/활동) 클릭 시 및 하단 "+" 버튼으로 질문 추가 시에도 동일하게 해당 질문 섹션으로 스크롤 이동하도록 `handleAddField`가 새로 생성된 질문의 id를 반환하도록 수정
- 위 과정에서 `templateFields` 상수의 `questionId`가 모듈 로드 시 한 번만 생성되어, 같은 템플릿을 여러 번 추가하면 동일한 id가 중복 부여되던 문제를 함께 수정(항목 추가 시 항상 새 id 생성)
- 리뷰어는 지원폼 작성/수정 화면 양쪽(`applicationForm/index.tsx`, `createform/step3/index.tsx`)에서 드롭다운 동작과 스크롤 이동이 동일하게 작동하는지 확인 부탁드립니다
- 특이사항 없음

### 📸 스크린샷

<img width="1031" height="391" alt="image" src="https://github.com/user-attachments/assets/57e4c680-02db-4b2e-9164-9aaed895c26b" />

### 연관 이슈

close #345
