### PR TITLE
로딩 스피너를 스켈레톤 UI로 교체하고 로그인/로그아웃 시 즐겨찾기 쿼리 무효화 추가(issue #348)

### DIFF
--- a/apps/web/src/app/(client-header)/(with-footer)/applied/page.tsx
+++ b/apps/web/src/app/(client-header)/(with-footer)/applied/page.tsx
@@ -5,10 +5,28 @@ import { useSearchQuery } from '@/hooks/useSearchQuery';
 import SortButtonGroup from '@/components/favorites/SortButtonGroup';
 import { useAppliedInfinite } from '@/hooks/useInfiniteCommon';
 import { Suspense } from 'react';
+import ClubItemSkeleton from '@/common/components/clubItem/ClubItemSkeleton';
+import * as ClubListStyles from '@/components/home/clubList/clubList.css';
+
+function AppliedSkeleton() {
+  return (
+    <div
+      className={ClubListStyles.container}
+      aria-busy="true"
+      aria-label="지원내역 목록을 불러오는 중입니다"
+    >
+      <ul className={ClubListStyles.innerWrapper}>
+        {Array.from({ length: 8 }).map((_, index) => (
+          <ClubItemSkeleton key={index} className={ClubListStyles.cardStyle} />
+        ))}
+      </ul>
+    </div>
+  );
+}
 
 export default function Page() {
   return (
-    <Suspense>
+    <Suspense fallback={<AppliedSkeleton />}>
       <AppliedPage />
     </Suspense>
   );

--- a/apps/web/src/app/(client-header)/(with-footer)/club/[clubId]/apply/page.tsx
+++ b/apps/web/src/app/(client-header)/(with-footer)/club/[clubId]/apply/page.tsx
@@ -4,8 +4,13 @@ import dynamic from 'next/dynamic';
 import * as S from '@/components/apply/index.css';
 import BackButton from '@/components/clubInfo/BackButton';
 import { useParams } from 'next/navigation';
+import { Suspense } from 'react';
+import FormSkeleton from '@/components/apply/FormSkeleton';
 
-const Form = dynamic(() => import('@/components/apply/Form'), { ssr: false });
+const Form = dynamic(() => import('@/components/apply/Form'), {
+  ssr: false,
+  loading: () => <FormSkeleton />,
+});
 
 export default function Page() {
   const params = useParams();
@@ -15,7 +20,9 @@ export default function Page() {
     <div className={S.wrapper}>
       <div className={S.container}>
         <BackButton title="지원 폼 작성" />
-        <Form clubId={clubId} />
+        <Suspense fallback={<FormSkeleton />}>
+          <Form clubId={clubId} />
+        </Suspense>
       </div>
     </div>
   );

--- a/apps/web/src/app/(client-header)/(with-footer)/favorites/page.tsx
+++ b/apps/web/src/app/(client-header)/(with-footer)/favorites/page.tsx
@@ -5,10 +5,28 @@ import { useSearchQuery } from '@/hooks/useSearchQuery';
 import SortButtonGroup from '@/components/favorites/SortButtonGroup';
 import { useFavoritesInfinite } from '@/hooks/useInfiniteCommon';
 import { Suspense } from 'react';
+import ClubItemSkeleton from '@/common/components/clubItem/ClubItemSkeleton';
+import * as ClubListStyles from '@/components/home/clubList/clubList.css';
+
+function FavoritesSkeleton() {
+  return (
+    <div
+      className={ClubListStyles.container}
+      aria-busy="true"
+      aria-label="즐겨찾기 목록을 불러오는 중입니다"
+    >
+      <ul className={ClubListStyles.innerWrapper}>
+        {Array.from({ length: 8 }).map((_, index) => (
+          <ClubItemSkeleton key={index} className={ClubListStyles.cardStyle} />
+        ))}
+      </ul>
+    </div>
+  );
+}
 
 export default function Page() {
   return (
-    <Suspense>
+    <Suspense fallback={<FavoritesSkeleton />}>
       <FavoritesPage />
     </Suspense>
   );

--- a/apps/web/src/app/(client-header)/(with-footer)/notice/[noticeId]/page.tsx
+++ b/apps/web/src/app/(client-header)/(with-footer)/notice/[noticeId]/page.tsx
@@ -9,21 +9,6 @@ interface NoticeDetailPageProps {
   }>;
 }
 
-export const revalidate = 60;
-export const dynamicParams = true;
-
-const fetchNoticeDetail = async (noticeId: string) => {
-  try {
-    return await getNoticeDetail({ noticeId });
-  } catch (error) {
-    if (error instanceof CustomHttpError && error.status === 404) {
-      throw new CustomHttpError(error.message, error.status);
-    }
-
-    throw error;
-  }
-};
-
 export async function generateMetadata({ params }: NoticeDetailPageProps): Promise<Metadata> {
   const { noticeId } = await params;
 

--- a/apps/web/src/app/(default-header)/(with-footer)/login/page.tsx
+++ b/apps/web/src/app/(default-header)/(with-footer)/login/page.tsx
@@ -3,10 +3,12 @@
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
 import * as S from '@/components/login/login.css';
 import Button from '@/common/ui/button/index';
 import { loginSchema, LoginForm } from '@/components/login/schema';
 import { ROUTES } from '@/common/constants/routes';
+import { userKey } from '@/hooks/queries/key';
 import { postLogin } from '@/components/login/api';
 import { initializeAndSendFCMToken } from '@/fcm/fcmToken';
 import GoogleLoginButton from '@/components/login/googleLogin';
@@ -16,6 +18,7 @@ import { useGoogleLogin } from '@/hooks/useGoogleLogin';
 
 export default function Page() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const {
     onboarding,
     completedSignupName,
@@ -45,6 +48,7 @@ export default function Page() {
       };
       const response = await postLogin(loginData);
       if (response.success) {
+        queryClient.invalidateQueries({ queryKey: userKey.favoritesClubList });
         // 로그인 성공 후 FCM 토큰 초기화 및 전달
         // 백그라운드에서 처리되므로 await하지 않아도 됩니다
         initializeAndSendFCMToken().catch((error) => {

--- a/apps/web/src/common/components/clubItem/ClubItemSkeleton.tsx
+++ b/apps/web/src/common/components/clubItem/ClubItemSkeleton.tsx
@@ -1,0 +1,24 @@
+import * as S from './clubItemSkeleton.css';
+
+interface ClubItemSkeletonProps {
+  className?: string;
+}
+
+function ClubItemSkeleton({ className = '' }: ClubItemSkeletonProps) {
+  return (
+    <li className={`${S.container} ${className}`} aria-hidden="true">
+      <div className={S.headerWrapper}>
+        <span className={`${S.skeletonBlock} ${S.type}`} />
+        <span className={`${S.skeletonBlock} ${S.star}`} />
+      </div>
+      <span className={`${S.skeletonBlock} ${S.name}`} />
+      <div className={S.tagWrapper}>
+        <span className={`${S.skeletonBlock} ${S.tag}`} />
+        <span className={`${S.skeletonBlock} ${S.tag}`} />
+        <span className={`${S.skeletonBlock} ${S.status}`} />
+      </div>
+    </li>
+  );
+}
+
+export default ClubItemSkeleton;

--- a/apps/web/src/common/components/clubItem/clubItemSkeleton.css.ts
+++ b/apps/web/src/common/components/clubItem/clubItemSkeleton.css.ts
@@ -1,0 +1,82 @@
+import { BREAKPOINTS } from '@/common/constants/breakpoints';
+import { keyframes, style } from '@vanilla-extract/css';
+
+const skeletonShimmer = keyframes({
+  '0%': {
+    backgroundPosition: '100% 0',
+  },
+  '100%': {
+    backgroundPosition: '-100% 0',
+  },
+});
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+  minWidth: '16.666rem',
+  maxWidth: '41rem',
+  width: '100%',
+  backgroundColor: '#FFFFFF',
+  padding: '16px',
+  borderRadius: '8px',
+});
+
+export const skeletonBlock = style({
+  display: 'block',
+  borderRadius: '6px',
+  background: 'linear-gradient(90deg, #eef1f5 25%, #f7f8fa 50%, #eef1f5 75%)',
+  backgroundSize: '200% 100%',
+  animation: `${skeletonShimmer} 1.2s ease-in-out infinite`,
+});
+
+export const headerWrapper = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  width: '100%',
+  marginBottom: '8px',
+  padding: '0 4px',
+});
+
+export const type = style({
+  width: '56px',
+  height: '16px',
+});
+
+export const star = style({
+  width: '20px',
+  height: '20px',
+  borderRadius: '50%',
+});
+
+export const name = style({
+  width: '62%',
+  height: '24px',
+  margin: '0 4px 14px',
+
+  '@media': {
+    [`screen and (max-width: ${BREAKPOINTS.tablet}px)`]: {
+      height: '22px',
+    },
+  },
+});
+
+export const tagWrapper = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+  width: '100%',
+  marginTop: '2px',
+});
+
+export const tag = style({
+  width: '58px',
+  height: '24px',
+  borderRadius: '999px',
+});
+
+export const status = style({
+  width: '72px',
+  height: '20px',
+});

--- a/apps/web/src/components/apply/FormSkeleton.tsx
+++ b/apps/web/src/components/apply/FormSkeleton.tsx
@@ -1,0 +1,51 @@
+import * as S from './form.css';
+
+function FormSkeleton() {
+  return (
+    <div className={S.wrapper} aria-busy="true" aria-label="지원폼을 불러오는 중입니다">
+      <div className={S.contentContainer}>
+        <div className={S.FormHeader}>
+          <span className={`${S.skeletonBlock} ${S.formTitleSkeleton}`} />
+          <span className={`${S.skeletonBlock} ${S.formSubTitleSkeleton}`} />
+        </div>
+
+        <section className={S.FormBasicContainer}>
+          <span className={`${S.skeletonBlock} ${S.sectionTitleSkeleton}`} />
+          <div className={S.skeletonFieldGrid}>
+            {Array.from({ length: 8 }).map((_, index) => (
+              <div key={index} className={S.skeletonFieldGroup}>
+                <span className={`${S.skeletonBlock} ${S.fieldLabelSkeleton}`} />
+                <span className={`${S.skeletonBlock} ${S.inputSkeleton}`} />
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {Array.from({ length: 3 }).map((_, index) => (
+          <section key={index} className={S.questionContainer}>
+            <div className={S.questionHeader}>
+              <span className={`${S.skeletonBlock} ${S.questionTitleSkeleton}`} />
+              <span className={`${S.skeletonBlock} ${S.questionSubTitleSkeleton}`} />
+            </div>
+            <span className={`${S.skeletonBlock} ${S.answerSkeleton}`} />
+          </section>
+        ))}
+      </div>
+
+      <aside className={S.rightSideContainer}>
+        <div className={S.BoxFlex}>
+          <span className={`${S.skeletonBlock} ${S.sidebarTitleSkeleton}`} />
+          <div className={S.BoxContentContainer}>
+            {Array.from({ length: 4 }).map((_, index) => (
+              <span key={index} className={`${S.skeletonBlock} ${S.sidebarItemSkeleton}`} />
+            ))}
+          </div>
+        </div>
+        <span className={`${S.skeletonBlock} ${S.sidebarButtonSkeleton}`} />
+        <span className={`${S.skeletonBlock} ${S.sidebarButtonSkeleton}`} />
+      </aside>
+    </div>
+  );
+}
+
+export default FormSkeleton;

--- a/apps/web/src/components/apply/form.css.ts
+++ b/apps/web/src/components/apply/form.css.ts
@@ -1,8 +1,18 @@
 ﻿import { createVar, style } from '@vanilla-extract/css';
+import { keyframes } from '@vanilla-extract/css';
 import { vars } from '@/common/styles/theme.css';
 import { BREAKPOINTS } from '@/common/constants/breakpoints';
 
 export const sidebarTop = createVar();
+
+const skeletonShimmer = keyframes({
+  '0%': {
+    backgroundPosition: '100% 0',
+  },
+  '100%': {
+    backgroundPosition: '-100% 0',
+  },
+});
 
 export const wrapper = style({
   display: 'flex',
@@ -500,4 +510,85 @@ export const hiddenCheckbox = style({
   left: '-9999px',
   opacity: 0,
   pointerEvents: 'none',
+});
+
+export const skeletonBlock = style({
+  display: 'block',
+  borderRadius: '6px',
+  background: 'linear-gradient(90deg, #eef1f5 25%, #f7f8fa 50%, #eef1f5 75%)',
+  backgroundSize: '200% 100%',
+  animation: `${skeletonShimmer} 1.2s ease-in-out infinite`,
+});
+
+export const formTitleSkeleton = style({
+  width: '42%',
+  height: '28px',
+});
+
+export const formSubTitleSkeleton = style({
+  width: '64%',
+  height: '20px',
+});
+
+export const sectionTitleSkeleton = style({
+  width: '140px',
+  height: '24px',
+});
+
+export const skeletonFieldGrid = style({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(2, 1fr)',
+  gap: '20px 12px',
+
+  '@media': {
+    [`screen and (max-width: ${BREAKPOINTS.desktop}px)`]: {
+      gridTemplateColumns: '1fr',
+    },
+  },
+});
+
+export const skeletonFieldGroup = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px',
+});
+
+export const fieldLabelSkeleton = style({
+  width: '88px',
+  height: '18px',
+});
+
+export const inputSkeleton = style({
+  width: '100%',
+  height: '46px',
+});
+
+export const questionTitleSkeleton = style({
+  width: '48%',
+  height: '24px',
+});
+
+export const questionSubTitleSkeleton = style({
+  width: '72%',
+  height: '18px',
+});
+
+export const answerSkeleton = style({
+  width: '100%',
+  height: '48px',
+});
+
+export const sidebarTitleSkeleton = style({
+  width: '74px',
+  height: '24px',
+});
+
+export const sidebarItemSkeleton = style({
+  width: '100%',
+  height: '18px',
+});
+
+export const sidebarButtonSkeleton = style({
+  width: '100%',
+  height: '54px',
 });

--- a/apps/web/src/components/clubInfo/ClubInfoSkeleton.tsx
+++ b/apps/web/src/components/clubInfo/ClubInfoSkeleton.tsx
@@ -1,0 +1,39 @@
+import * as S from './index.css';
+import BackButton from './BackButton';
+
+function ClubInfoSkeleton() {
+  return (
+    <div className={S.wrapper} aria-busy="true" aria-label="동아리 정보를 불러오는 중입니다">
+      <div className={S.container}>
+        <div className={S.leftcontainer}>
+          <BackButton />
+          <section className={S.profileSkeleton}>
+            <span className={`${S.skeletonBlock} ${S.profileImageSkeleton}`} />
+            <div className={S.profileTextSkeleton}>
+              <span className={`${S.skeletonBlock} ${S.clubNameSkeleton}`} />
+              <span className={`${S.skeletonBlock} ${S.clubSummarySkeleton}`} />
+              <div className={S.profileTagsSkeleton}>
+                <span className={`${S.skeletonBlock} ${S.tagSkeleton}`} />
+                <span className={`${S.skeletonBlock} ${S.tagSkeleton}`} />
+              </div>
+            </div>
+          </section>
+          <section className={S.introSkeleton}>
+            <span className={`${S.skeletonBlock} ${S.introTitleSkeleton}`} />
+            <span className={`${S.skeletonBlock} ${S.introLineSkeleton}`} />
+            <span className={`${S.skeletonBlock} ${S.introLineSkeleton}`} />
+            <span className={`${S.skeletonBlock} ${S.introLineShortSkeleton}`} />
+          </section>
+        </div>
+        <aside className={S.rightSkeleton}>
+          <span className={`${S.skeletonBlock} ${S.sideTitleSkeleton}`} />
+          <span className={`${S.skeletonBlock} ${S.sideButtonSkeleton}`} />
+          <span className={`${S.skeletonBlock} ${S.sideLineSkeleton}`} />
+          <span className={`${S.skeletonBlock} ${S.sideLineSkeleton}`} />
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+export default ClubInfoSkeleton;

--- a/apps/web/src/components/clubInfo/index.css.ts
+++ b/apps/web/src/components/clubInfo/index.css.ts
@@ -1,5 +1,16 @@
 ﻿import { style } from '@vanilla-extract/css';
+import { keyframes } from '@vanilla-extract/css';
 import { BREAKPOINTS } from '@/common/constants/breakpoints';
+import { vars } from '@/common/styles/theme.css';
+
+const skeletonShimmer = keyframes({
+  '0%': {
+    backgroundPosition: '100% 0',
+  },
+  '100%': {
+    backgroundPosition: '-100% 0',
+  },
+});
 
 export const wrapper = style({
   display: 'flex',
@@ -44,4 +55,129 @@ export const leftcontainer = style({
       gap: '16px',
     },
   },
+});
+
+export const skeletonBlock = style({
+  display: 'block',
+  borderRadius: '6px',
+  background: 'linear-gradient(90deg, #eef1f5 25%, #f7f8fa 50%, #eef1f5 75%)',
+  backgroundSize: '200% 100%',
+  animation: `${skeletonShimmer} 1.2s ease-in-out infinite`,
+});
+
+export const profileSkeleton = style({
+  display: 'flex',
+  gap: '24px',
+  padding: '28px',
+  borderRadius: '8px',
+  backgroundColor: vars.colors.white,
+
+  '@media': {
+    [`screen and (max-width: ${BREAKPOINTS.desktop}px)`]: {
+      flexDirection: 'column',
+      padding: '20px',
+    },
+  },
+});
+
+export const profileImageSkeleton = style({
+  width: '180px',
+  height: '180px',
+  flexShrink: 0,
+
+  '@media': {
+    [`screen and (max-width: ${BREAKPOINTS.desktop}px)`]: {
+      width: '100%',
+      height: '180px',
+    },
+  },
+});
+
+export const profileTextSkeleton = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '14px',
+  flexGrow: 1,
+});
+
+export const clubNameSkeleton = style({
+  width: '42%',
+  height: '32px',
+});
+
+export const clubSummarySkeleton = style({
+  width: '76%',
+  height: '20px',
+});
+
+export const profileTagsSkeleton = style({
+  display: 'flex',
+  gap: '8px',
+});
+
+export const tagSkeleton = style({
+  width: '72px',
+  height: '28px',
+  borderRadius: '999px',
+});
+
+export const introSkeleton = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '14px',
+  padding: '28px',
+  borderRadius: '8px',
+  backgroundColor: vars.colors.white,
+});
+
+export const introTitleSkeleton = style({
+  width: '160px',
+  height: '28px',
+});
+
+export const introLineSkeleton = style({
+  width: '100%',
+  height: '18px',
+});
+
+export const introLineShortSkeleton = style({
+  width: '64%',
+  height: '18px',
+});
+
+export const rightSkeleton = style({
+  position: 'relative',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '16px',
+  flexBasis: '330px',
+  top: '124px',
+  flexShrink: 0,
+  flexGrow: 0,
+  padding: '24px',
+  borderRadius: '8px',
+  backgroundColor: vars.colors.white,
+  alignSelf: 'flex-start',
+
+  '@media': {
+    [`screen and (max-width: ${BREAKPOINTS.largeDesktop}px)`]: {
+      display: 'none',
+      top: '0',
+    },
+  },
+});
+
+export const sideTitleSkeleton = style({
+  width: '120px',
+  height: '24px',
+});
+
+export const sideButtonSkeleton = style({
+  width: '100%',
+  height: '48px',
+});
+
+export const sideLineSkeleton = style({
+  width: '100%',
+  height: '18px',
 });

--- a/apps/web/src/components/clubInfo/index.tsx
+++ b/apps/web/src/components/clubInfo/index.tsx
@@ -9,8 +9,8 @@ import ClubIntroduce from '@/components/clubInfo/ClubIntro';
 import RightSide from '@/components/clubInfo/RightSide';
 import { useParams } from 'next/navigation';
 import { useClubInfo } from '@/hooks/useClubInfo';
-import LoadingSpinner from '@/common/ui/loading';
 import { useScrollTop } from '@/hooks/useScrollTop';
+import ClubInfoSkeleton from './ClubInfoSkeleton';
 
 const ClubInfoPage = () => {
   const { clubId } = useParams();
@@ -31,7 +31,7 @@ const ClubInfoPage = () => {
 
   return (
     <>
-      <Suspense fallback={<LoadingSpinner />}>
+      <Suspense fallback={<ClubInfoSkeleton />}>
         <div className={S.wrapper}>
           <div className={S.container}>
             <div className={S.leftcontainer}>
@@ -49,4 +49,7 @@ const ClubInfoPage = () => {
   );
 };
 
-export default dynamic(() => Promise.resolve(ClubInfoPage), { ssr: false });
+export default dynamic(() => Promise.resolve(ClubInfoPage), {
+  ssr: false,
+  loading: () => <ClubInfoSkeleton />,
+});

--- a/apps/web/src/components/favorites/InfiniteClublist.tsx
+++ b/apps/web/src/components/favorites/InfiniteClublist.tsx
@@ -3,6 +3,7 @@
 import { useInView } from 'react-intersection-observer';
 import * as S from '@/components/home/clubList/clubList.css';
 import ClubItem from '@/common/components/clubItem';
+import ClubItemSkeleton from '@/common/components/clubItem/ClubItemSkeleton';
 import { useEffect, useState } from 'react';
 import { SearchQueryReturn } from '@/hooks/useSearchQuery';
 import * as F from './favorites.css';
@@ -10,7 +11,6 @@ import Empty from '@/common/components/empty';
 import { Clubs, ClubsInfiniteWithTotal } from '@/common/model/clubInfinite';
 import { ClubItemInfo } from '@/common/model/club';
 import type { InfiniteData } from '@tanstack/react-query';
-import LoadingSpinner from '@/common/ui/loading';
 import { useModal } from '@/hooks/useModal';
 import ConfirmModal from '@/common/components/confirmModal';
 
@@ -84,7 +84,17 @@ function InfiniteClubList({
     handleModalOpen();
   };
 
-  if (isLoading) return <LoadingSpinner />;
+  if (isLoading) {
+    return (
+      <div className={S.container} aria-busy="true" aria-label={`${title} 목록을 불러오는 중입니다`}>
+        <ul className={S.innerWrapper}>
+          {Array.from({ length: 8 }).map((_, index) => (
+            <ClubItemSkeleton key={index} className={S.cardStyle} />
+          ))}
+        </ul>
+      </div>
+    );
+  }
 
   return (
     <>
@@ -109,8 +119,12 @@ function InfiniteClubList({
       <div ref={ref} style={{ height: 1 }} />
 
       {isFetchingNextPage && (
-        <div className={F.lottieContainer}>
-          <LoadingSpinner />
+        <div className={S.container}>
+          <ul className={S.innerWrapper} aria-hidden="true">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <ClubItemSkeleton key={index} className={S.cardStyle} />
+            ))}
+          </ul>
         </div>
       )}
 

--- a/apps/web/src/components/home/clubList/index.tsx
+++ b/apps/web/src/components/home/clubList/index.tsx
@@ -2,11 +2,11 @@
 import { useClubsInfinite } from '@/hooks/useClubsInfinite';
 import * as S from './clubList.css';
 import ClubItem from '@/common/components/clubItem';
+import ClubItemSkeleton from '@/common/components/clubItem/ClubItemSkeleton';
 import { SearchQueryReturn } from '@/hooks/useSearchQuery';
 import { useInView } from 'react-intersection-observer';
 import { useEffect, useState } from 'react';
 import Empty from '@/common/components/empty';
-import LoadingSpinner from '@/common/ui/loading';
 import { useModal } from '@/hooks/useModal';
 import ConfirmModal from '@/common/components/confirmModal';
 interface ClubListProps {
@@ -36,7 +36,15 @@ function ClubList({ selectedOptions }: ClubListProps) {
   }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   if (isLoading) {
-    return <LoadingSpinner />;
+    return (
+      <div className={S.container} aria-busy="true" aria-label="동아리 목록을 불러오는 중입니다">
+        <ul className={S.innerWrapper}>
+          {Array.from({ length: 8 }).map((_, index) => (
+            <ClubItemSkeleton key={index} className={S.cardStyle} />
+          ))}
+        </ul>
+      </div>
+    );
   }
 
   return (
@@ -56,6 +64,13 @@ function ClubList({ selectedOptions }: ClubListProps) {
       )}
       {isEmpty && <Empty className={S.emptyText}>동아리 목록이 없습니다</Empty>}
       <div ref={ref} />
+      {isFetchingNextPage && (
+        <ul className={S.innerWrapper} aria-hidden="true">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <ClubItemSkeleton key={index} className={S.cardStyle} />
+          ))}
+        </ul>
+      )}
       <ConfirmModal isOpen={isOpen} onClose={handleModalClose}>
         {favoriteModalMessage}
       </ConfirmModal>

--- a/apps/web/src/components/home/page.tsx
+++ b/apps/web/src/components/home/page.tsx
@@ -1,13 +1,30 @@
 'use client';
-import LoadingSpinner from '@/common/ui/loading';
+import ClubItemSkeleton from '@/common/components/clubItem/ClubItemSkeleton';
 import QueryErrorBoundary from '@/components/error/queryErrorBoundary';
 import ClubList from '@/components/home/clubList';
+import * as ClubListStyles from '@/components/home/clubList/clubList.css';
 import Filter from '@/components/home/filter';
 import PopularClubList from '@/components/home/popularClubList/index';
 import * as S from '@/components/home/popularClubList/popularClubList.css';
 import { Suspense } from 'react';
 interface HomePageProps {
   filter: Record<string, string | string[] | undefined>;
+}
+
+function HomeClubListSkeleton() {
+  return (
+    <div
+      className={ClubListStyles.container}
+      aria-busy="true"
+      aria-label="동아리 목록을 불러오는 중입니다"
+    >
+      <ul className={ClubListStyles.innerWrapper}>
+        {Array.from({ length: 8 }).map((_, index) => (
+          <ClubItemSkeleton key={index} className={ClubListStyles.cardStyle} />
+        ))}
+      </ul>
+    </div>
+  );
 }
 
 function HomePage({ filter }: HomePageProps) {
@@ -21,7 +38,7 @@ function HomePage({ filter }: HomePageProps) {
         </div>
       </div>
       <Filter selectedOptions={filter} />
-      <Suspense fallback={<LoadingSpinner />}>
+      <Suspense fallback={<HomeClubListSkeleton />}>
         <QueryErrorBoundary>
           <ClubList selectedOptions={filter} />
         </QueryErrorBoundary>

--- a/apps/web/src/components/home/popularClubList/index.tsx
+++ b/apps/web/src/components/home/popularClubList/index.tsx
@@ -3,8 +3,19 @@ import ClubList from './clubList';
 import Slider from './slider';
 import Link from 'next/link';
 import { ROUTES } from '@/common/constants/routes';
-import LoadingSpinner from '@/common/ui/loading';
+import ClubItemSkeleton from '@/common/components/clubItem/ClubItemSkeleton';
 import { Suspense } from 'react';
+
+function PopularClubListSkeleton() {
+  return (
+    <ul className={S.PopularClubListWrapper} aria-hidden="true">
+      {Array.from({ length: 4 }).map((_, index) => (
+        <ClubItemSkeleton key={index} className={S.cardStyle} />
+      ))}
+    </ul>
+  );
+}
+
 function PopularClubList() {
   return (
     <div>
@@ -14,7 +25,13 @@ function PopularClubList() {
           <p className={S.Plus}>더보기</p>
         </Link>
       </div>
-      <Suspense fallback={<LoadingSpinner />}>
+      <Suspense
+        fallback={
+          <Slider>
+            <PopularClubListSkeleton />
+          </Slider>
+        }
+      >
         <Slider>
           <ClubList />
         </Slider>

--- a/apps/web/src/hooks/useGoogleLogin.ts
+++ b/apps/web/src/hooks/useGoogleLogin.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
 import { CustomHttpError } from '@/common/apis/apiClient';
 import { HTTP_STATUS } from '@/common/constants/httpStatus';
 import { GA_EVENTS, GA_METHODS } from '@/common/constants/gaEvents';
@@ -8,6 +9,7 @@ import { ROUTES } from '@/common/constants/routes';
 import { postGoogleLogin, postGoogleOnboarding } from '@/components/login/api/google';
 import type { GoogleLoginNeedsOnboarding } from '@/components/login/model';
 import { initializeAndSendFCMToken } from '@/fcm/fcmToken';
+import { userKey } from '@/hooks/queries/key';
 import { trackGAEvent } from '@/lib/ga';
 
 type OnboardingState = Omit<GoogleLoginNeedsOnboarding, 'needsOnboarding'>;
@@ -28,17 +30,19 @@ const getLoginErrorMessage = (error: unknown) => {
 
 export const useGoogleLogin = () => {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const [onboarding, setOnboarding] = useState<OnboardingState | null>(null);
   const [completedSignupName, setCompletedSignupName] = useState('');
   const [isPending, setIsPending] = useState(false);
 
   const completeLogin = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: userKey.favoritesClubList });
     // FCM 토큰은 백그라운드에서 처리되므로 await하지 않는다.
     initializeAndSendFCMToken().catch((error) => {
       console.error('FCM 토큰 초기화 실패:', error);
     });
     router.push(ROUTES.HOME);
-  }, [router]);
+  }, [queryClient, router]);
 
   /** GIS 콜백에서 받은 ID 토큰으로 로그인한다. */
   const handleCredential = useCallback(

--- a/apps/web/src/hooks/useUserMutaion.ts
+++ b/apps/web/src/hooks/useUserMutaion.ts
@@ -1,9 +1,12 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { postLogout } from '@/components/login/api';
 import { CustomHttpError } from '@/common/apis/apiClient';
 import { clearFCMToken } from '@/fcm/fcmToken';
+import { userKey } from './queries/key';
 
 export const useLogoutMutation = () => {
+  const queryClient = useQueryClient();
+
   const logoutMutation = useMutation({
     mutationFn: async () => {
       await clearFCMToken();
@@ -13,6 +16,7 @@ export const useLogoutMutation = () => {
       localStorage.removeItem('name');
       localStorage.removeItem('user_access_token');
       localStorage.removeItem('user_refresh_token');
+      queryClient.invalidateQueries({ queryKey: userKey.favoritesClubList });
 
       window.location.href = '/login';
     },


### PR DESCRIPTION
### 작업 내용

- 지원내역/즐겨찾기/지원폼 작성/동아리 상세/홈 동아리 목록·인기 동아리 목록의 `LoadingSpinner` 또는 빈 `Suspense` fallback을, 실제 콘텐츠 구조를 본뜬 스켈레톤 UI로 교체해 로딩 시 레이아웃 시프트를 줄이고 체감 속도를 개선했습니다.
- 목록형 화면에서 공통으로 쓸 수 있는 `ClubItemSkeleton` 컴포넌트를 신설해 홈/즐겨찾기/지원내역/인기 동아리 목록에서 재사용하고, 무한스크롤 다음 페이지 로딩(`isFetchingNextPage`) 시에도 동일한 스켈레톤이 보이도록 했습니다.
- 지원폼 작성 페이지에는 실제 폼 레이아웃(기본정보 + 질문 섹션 + 사이드바)을 본뜬 `FormSkeleton`을 추가했습니다.
- 로그인(이메일/구글) 성공 및 로그아웃 시 즐겨찾기 목록 쿼리(`userKey.favoritesClubList`)를 무효화하도록 추가해, 계정을 바꿔가며 로그인해도 즐겨찾기 목록이 이전 계정의 캐시로 남아있지 않도록 수정했습니다.
- 공지사항 상세 페이지는 사용하지 않게 된 ISR 설정(`revalidate`, `dynamicParams`)과 관련 헬퍼를 정리했습니다.
- 스켈레톤 UI 작업과 로그인/로그아웃 쿼리 무효화 작업은 서로 다른 관심사라, 리뷰 시 두 커밋을 구분해서 봐주시면 좋을 것 같습니다.
- 리뷰어는 무한스크롤 로딩 중 스켈레톤 개수·레이아웃이 실제 카드와 자연스럽게 이어지는지, 그리고 계정을 전환하며 로그인/로그아웃했을 때 즐겨찾기 목록이 올바르게 갱신되는지 확인 부탁드립니다.
- `skeletonShimmer` keyframes가 `clubItemSkeleton.css.ts`/`form.css.ts`/`clubInfo/index.css.ts`에 동일하게 중복 정의돼 있는데, 공통 유틸로 뺄지 이번 PR 범위로 남길지 논의하고 싶습니다.

### 📸 스크린샷

| As-is | To-be |
| ----- | ----- |
|       |       |

### 연관 이슈

close #348
